### PR TITLE
Add finance management models and admin pages

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -3,8 +3,8 @@ from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.utils import secure_filename
 import os
 from datetime import datetime
-from models import GalleryItem
-from forms import GalleryForm
+from models import GalleryItem, BillingRecord, Invoice, Convenio
+from forms import GalleryForm, BillingRecordForm, InvoiceForm, ConvenioForm
 from forms import LoginForm, EventForm, SettingsForm
 from models import db, User, Event, Appointment, Settings
 
@@ -206,3 +206,124 @@ def delete_gallery_item(item_id):
     db.session.commit()
     flash('Item removido com sucesso!', 'success')
     return redirect(url_for('admin_bp.gallery'))
+
+
+@admin_bp.route('/billings')
+@login_required
+def billings():
+    records = BillingRecord.query.order_by(BillingRecord.created_at.desc()).all()
+    return render_template('admin/billings.html', records=records)
+
+
+@admin_bp.route('/billings/add', methods=['GET', 'POST'])
+@login_required
+def add_billing():
+    form = BillingRecordForm()
+    if form.validate_on_submit():
+        record = BillingRecord(
+            patient_name=form.patient_name.data,
+            description=form.description.data,
+            amount=form.amount.data,
+            status=form.status.data
+        )
+        db.session.add(record)
+        db.session.commit()
+        flash('Registro de faturamento adicionado!', 'success')
+        return redirect(url_for('admin_bp.billings'))
+    return render_template('admin/billing_form.html', form=form, title='Novo Faturamento')
+
+
+@admin_bp.route('/billings/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
+def edit_billing(id):
+    record = BillingRecord.query.get_or_404(id)
+    form = BillingRecordForm(obj=record)
+    if form.validate_on_submit():
+        record.patient_name = form.patient_name.data
+        record.description = form.description.data
+        record.amount = form.amount.data
+        record.status = form.status.data
+        db.session.commit()
+        flash('Registro atualizado!', 'success')
+        return redirect(url_for('admin_bp.billings'))
+    return render_template('admin/billing_form.html', form=form, title='Editar Faturamento')
+
+
+@admin_bp.route('/invoices')
+@login_required
+def invoices():
+    invoices = Invoice.query.order_by(Invoice.created_at.desc()).all()
+    return render_template('admin/invoices.html', invoices=invoices)
+
+
+@admin_bp.route('/invoices/add', methods=['GET', 'POST'])
+@login_required
+def add_invoice():
+    form = InvoiceForm()
+    if form.validate_on_submit():
+        invoice = Invoice(
+            number=form.number.data,
+            amount=form.amount.data,
+            due_date=form.due_date.data,
+            status=form.status.data
+        )
+        db.session.add(invoice)
+        db.session.commit()
+        flash('Nota fiscal adicionada!', 'success')
+        return redirect(url_for('admin_bp.invoices'))
+    return render_template('admin/invoice_form.html', form=form, title='Nova Nota Fiscal')
+
+
+@admin_bp.route('/invoices/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
+def edit_invoice(id):
+    invoice = Invoice.query.get_or_404(id)
+    form = InvoiceForm(obj=invoice)
+    if form.validate_on_submit():
+        invoice.number = form.number.data
+        invoice.amount = form.amount.data
+        invoice.due_date = form.due_date.data
+        invoice.status = form.status.data
+        db.session.commit()
+        flash('Nota fiscal atualizada!', 'success')
+        return redirect(url_for('admin_bp.invoices'))
+    return render_template('admin/invoice_form.html', form=form, title='Editar Nota Fiscal')
+
+
+@admin_bp.route('/convenios')
+@login_required
+def convenios():
+    convenios = Convenio.query.order_by(Convenio.created_at.desc()).all()
+    return render_template('admin/convenios.html', convenios=convenios)
+
+
+@admin_bp.route('/convenios/add', methods=['GET', 'POST'])
+@login_required
+def add_convenio():
+    form = ConvenioForm()
+    if form.validate_on_submit():
+        convenio = Convenio(
+            name=form.name.data,
+            details=form.details.data,
+            status=form.status.data
+        )
+        db.session.add(convenio)
+        db.session.commit()
+        flash('Convênio adicionado!', 'success')
+        return redirect(url_for('admin_bp.convenios'))
+    return render_template('admin/convenio_form.html', form=form, title='Novo Convênio')
+
+
+@admin_bp.route('/convenios/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
+def edit_convenio(id):
+    convenio = Convenio.query.get_or_404(id)
+    form = ConvenioForm(obj=convenio)
+    if form.validate_on_submit():
+        convenio.name = form.name.data
+        convenio.details = form.details.data
+        convenio.status = form.status.data
+        db.session.commit()
+        flash('Convênio atualizado!', 'success')
+        return redirect(url_for('admin_bp.convenios'))
+    return render_template('admin/convenio_form.html', form=form, title='Editar Convênio')

--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField, FileAllowed
-from wtforms import StringField, PasswordField, TextAreaField, DateField, TimeField, BooleanField, SubmitField
+from wtforms import StringField, PasswordField, TextAreaField, DateField, TimeField, BooleanField, SubmitField, FloatField
 from wtforms.validators import DataRequired, Email, ValidationError, Length, Optional
 from datetime import date
 from wtforms import SelectField
@@ -76,5 +76,28 @@ class GalleryForm(FlaskForm):
         ('eventos', 'Eventos'),
         ('videos', 'Vídeos')
     ], validators=[DataRequired()])
+    submit = SubmitField('Salvar')
+
+
+class BillingRecordForm(FlaskForm):
+    patient_name = StringField('Paciente', validators=[DataRequired()])
+    description = TextAreaField('Descrição', validators=[Optional()])
+    amount = FloatField('Valor', validators=[DataRequired()])
+    status = SelectField('Status', choices=[('pending', 'Pendente'), ('paid', 'Pago'), ('cancelled', 'Cancelado')], validators=[DataRequired()])
+    submit = SubmitField('Salvar')
+
+
+class InvoiceForm(FlaskForm):
+    number = StringField('Número', validators=[DataRequired()])
+    amount = FloatField('Valor', validators=[DataRequired()])
+    due_date = DateField('Vencimento', validators=[DataRequired()])
+    status = SelectField('Status', choices=[('pending', 'Pendente'), ('paid', 'Pago'), ('cancelled', 'Cancelado')], validators=[DataRequired()])
+    submit = SubmitField('Salvar')
+
+
+class ConvenioForm(FlaskForm):
+    name = StringField('Nome', validators=[DataRequired()])
+    details = TextAreaField('Detalhes', validators=[Optional()])
+    status = SelectField('Status', choices=[('active', 'Ativo'), ('inactive', 'Inativo')], validators=[DataRequired()])
     submit = SubmitField('Salvar')
 

--- a/models.py
+++ b/models.py
@@ -92,3 +92,38 @@ class GalleryItem(db.Model):
     caption = db.Column(db.String(255), nullable=True)
     categoria = db.Column(db.String(50), nullable=False, default='eventos')  # ✅ campo de categoria adicionado corretamente
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class BillingRecord(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    patient_name = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text)
+    amount = db.Column(db.Float, nullable=False)
+    status = db.Column(db.String(20), default='pending')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<BillingRecord {self.patient_name} - {self.amount}>'
+
+
+class Invoice(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    number = db.Column(db.String(50), unique=True, nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    due_date = db.Column(db.Date, nullable=False)
+    status = db.Column(db.String(20), default='pending')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<Invoice {self.number}>'
+
+
+class Convenio(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    details = db.Column(db.Text)
+    status = db.Column(db.String(20), default='active')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<Convenio {self.name}>'

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -171,6 +171,28 @@
                         </li>
                     </ul>
 
+                    <div class="sidebar-header mt-4">Financeiro</div>
+                    <ul class="nav flex-column">
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint == 'admin_bp.billings' %}active{% endif %}" href="{{ url_for('admin_bp.billings') }}">
+                                <i class="fas fa-file-invoice-dollar"></i>
+                                Faturamentos
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint == 'admin_bp.invoices' %}active{% endif %}" href="{{ url_for('admin_bp.invoices') }}">
+                                <i class="fas fa-file-invoice"></i>
+                                Notas Fiscais
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint == 'admin_bp.convenios' %}active{% endif %}" href="{{ url_for('admin_bp.convenios') }}">
+                                <i class="fas fa-handshake"></i>
+                                Convênios
+                            </a>
+                        </li>
+                    </ul>
+
                     <div class="sidebar-header mt-4">Sistema</div>
                     <ul class="nav flex-column">
                         <li class="nav-item">

--- a/templates/admin/billing_form.html
+++ b/templates/admin/billing_form.html
@@ -1,0 +1,32 @@
+{% extends "admin/base.html" %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+<h1 class="mb-4">{{ title }}</h1>
+<div class="card shadow">
+    <div class="card-body">
+        <form method="POST">
+            {{ form.hidden_tag() }}
+            <div class="mb-3">
+                {{ form.patient_name.label(class="form-label") }}
+                {{ form.patient_name(class="form-control") }}
+            </div>
+            <div class="mb-3">
+                {{ form.description.label(class="form-label") }}
+                {{ form.description(class="form-control") }}
+            </div>
+            <div class="mb-3">
+                {{ form.amount.label(class="form-label") }}
+                {{ form.amount(class="form-control") }}
+            </div>
+            <div class="mb-3">
+                {{ form.status.label(class="form-label") }}
+                {{ form.status(class="form-select") }}
+            </div>
+            <div class="d-flex justify-content-between">
+                <a href="{{ url_for('admin_bp.billings') }}" class="btn btn-secondary">Cancelar</a>
+                {{ form.submit(class="btn btn-primary") }}
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/billings.html
+++ b/templates/admin/billings.html
@@ -1,0 +1,44 @@
+{% extends "admin/base.html" %}
+{% block title %}Faturamentos{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Faturamentos</h1>
+    <a href="{{ url_for('admin_bp.add_billing') }}" class="btn btn-primary">
+        <i class="fas fa-plus"></i> Novo
+    </a>
+</div>
+<div class="card shadow">
+    <div class="card-body">
+        {% if records %}
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>Paciente</th>
+                        <th>Valor</th>
+                        <th>Status</th>
+                        <th>Data</th>
+                        <th>Ações</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for r in records %}
+                    <tr>
+                        <td>{{ r.patient_name }}</td>
+                        <td>R$ {{ '%.2f'|format(r.amount) }}</td>
+                        <td>{{ r.status }}</td>
+                        <td>{{ r.created_at.strftime('%d/%m/%Y') }}</td>
+                        <td>
+                            <a href="{{ url_for('admin_bp.edit_billing', id=r.id) }}" class="btn btn-sm btn-outline-primary">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-center">Nenhum registro encontrado.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/convenio_form.html
+++ b/templates/admin/convenio_form.html
@@ -1,0 +1,28 @@
+{% extends "admin/base.html" %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+<h1 class="mb-4">{{ title }}</h1>
+<div class="card shadow">
+    <div class="card-body">
+        <form method="POST">
+            {{ form.hidden_tag() }}
+            <div class="mb-3">
+                {{ form.name.label(class="form-label") }}
+                {{ form.name(class="form-control") }}
+            </div>
+            <div class="mb-3">
+                {{ form.details.label(class="form-label") }}
+                {{ form.details(class="form-control") }}
+            </div>
+            <div class="mb-3">
+                {{ form.status.label(class="form-label") }}
+                {{ form.status(class="form-select") }}
+            </div>
+            <div class="d-flex justify-content-between">
+                <a href="{{ url_for('admin_bp.convenios') }}" class="btn btn-secondary">Cancelar</a>
+                {{ form.submit(class="btn btn-primary") }}
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/convenios.html
+++ b/templates/admin/convenios.html
@@ -1,0 +1,40 @@
+{% extends "admin/base.html" %}
+{% block title %}Convênios{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Convênios</h1>
+    <a href="{{ url_for('admin_bp.add_convenio') }}" class="btn btn-primary">
+        <i class="fas fa-plus"></i> Novo
+    </a>
+</div>
+<div class="card shadow">
+    <div class="card-body">
+        {% if convenios %}
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>Nome</th>
+                        <th>Status</th>
+                        <th>Ações</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for c in convenios %}
+                    <tr>
+                        <td>{{ c.name }}</td>
+                        <td>{{ c.status }}</td>
+                        <td>
+                            <a href="{{ url_for('admin_bp.edit_convenio', id=c.id) }}" class="btn btn-sm btn-outline-primary">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-center">Nenhum convênio encontrado.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/invoice_form.html
+++ b/templates/admin/invoice_form.html
@@ -1,0 +1,32 @@
+{% extends "admin/base.html" %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+<h1 class="mb-4">{{ title }}</h1>
+<div class="card shadow">
+    <div class="card-body">
+        <form method="POST">
+            {{ form.hidden_tag() }}
+            <div class="mb-3">
+                {{ form.number.label(class="form-label") }}
+                {{ form.number(class="form-control") }}
+            </div>
+            <div class="mb-3">
+                {{ form.amount.label(class="form-label") }}
+                {{ form.amount(class="form-control") }}
+            </div>
+            <div class="mb-3">
+                {{ form.due_date.label(class="form-label") }}
+                {{ form.due_date(class="form-control", type="date") }}
+            </div>
+            <div class="mb-3">
+                {{ form.status.label(class="form-label") }}
+                {{ form.status(class="form-select") }}
+            </div>
+            <div class="d-flex justify-content-between">
+                <a href="{{ url_for('admin_bp.invoices') }}" class="btn btn-secondary">Cancelar</a>
+                {{ form.submit(class="btn btn-primary") }}
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/invoices.html
+++ b/templates/admin/invoices.html
@@ -1,0 +1,44 @@
+{% extends "admin/base.html" %}
+{% block title %}Notas Fiscais{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Notas Fiscais</h1>
+    <a href="{{ url_for('admin_bp.add_invoice') }}" class="btn btn-primary">
+        <i class="fas fa-plus"></i> Nova
+    </a>
+</div>
+<div class="card shadow">
+    <div class="card-body">
+        {% if invoices %}
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>Número</th>
+                        <th>Valor</th>
+                        <th>Vencimento</th>
+                        <th>Status</th>
+                        <th>Ações</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for inv in invoices %}
+                    <tr>
+                        <td>{{ inv.number }}</td>
+                        <td>R$ {{ '%.2f'|format(inv.amount) }}</td>
+                        <td>{{ inv.due_date.strftime('%d/%m/%Y') }}</td>
+                        <td>{{ inv.status }}</td>
+                        <td>
+                            <a href="{{ url_for('admin_bp.edit_invoice', id=inv.id) }}" class="btn btn-sm btn-outline-primary">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-center">Nenhuma nota fiscal encontrada.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add BillingRecord, Invoice and Convenio models
- create forms for billing records, invoices and convênios
- implement admin routes and templates for managing these records
- include new finance navigation section in admin sidebar

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68818c6aae3c832487b419cb62a74acd