### PR TITLE
Add public courses listing and enrollment

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -101,3 +101,10 @@ class ConvenioForm(FlaskForm):
     status = SelectField('Status', choices=[('active', 'Ativo'), ('inactive', 'Inativo')], validators=[DataRequired()])
     submit = SubmitField('Salvar')
 
+
+class CourseEnrollmentForm(FlaskForm):
+    name = StringField('Nome', validators=[DataRequired(), Length(min=3, max=100)])
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    phone = StringField('Telefone', validators=[DataRequired(), Length(min=8, max=20)])
+    submit = SubmitField('Enviar Inscrição')
+

--- a/models.py
+++ b/models.py
@@ -118,6 +118,29 @@ class Invoice(db.Model):
         return f'<Invoice {self.number}>'
 
 
+class Course(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(150), nullable=False)
+    description = db.Column(db.Text)
+    image = db.Column(db.String(255))
+    is_active = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<Course {self.title}>'
+
+
+class CourseEnrollment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    course_id = db.Column(db.Integer, db.ForeignKey('course.id'), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    email = db.Column(db.String(100), nullable=False)
+    phone = db.Column(db.String(20))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    course = db.relationship('Course', backref=db.backref('enrollments', lazy=True))
+
+
 class Convenio(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False)

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,6 +32,9 @@
                         <a class="nav-link" href="{{ url_for('main_bp.events') }}">Eventos</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('main_bp.courses') }}">Cursos</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('main_bp.appointment') }}">Agendar Consulta</a>
                     </li>
                     <li class="nav-item">

--- a/templates/course_detail.html
+++ b/templates/course_detail.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block title %}{{ course.title }}{% endblock %}
+{% block body_class %}dark-theme{% endblock %}
+
+{% block content %}
+<div class="container py-5 mt-5">
+    <div class="row">
+        <div class="col-md-8">
+            <h1 class="mb-4">{{ course.title }}</h1>
+            {% if course.image %}
+                <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="img-fluid mb-4" alt="{{ course.title }}">
+            {% endif %}
+            <div>{{ course.description|safe }}</div>
+        </div>
+        <div class="col-md-4">
+            <div class="card bg-dark-blue shadow border-0">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Inscreva-se</h5>
+                    <form method="POST">
+                        {{ form.csrf_token }}
+                        <div class="mb-3">
+                            {{ form.name.label(class="form-label text-light") }}
+                            {{ form.name(class="form-control bg-darker text-white") }}
+                            {% for error in form.name.errors %}
+                                <div class="invalid-feedback d-block">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        <div class="mb-3">
+                            {{ form.email.label(class="form-label text-light") }}
+                            {{ form.email(class="form-control bg-darker text-white") }}
+                            {% for error in form.email.errors %}
+                                <div class="invalid-feedback d-block">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        <div class="mb-3">
+                            {{ form.phone.label(class="form-label text-light") }}
+                            {{ form.phone(class="form-control bg-darker text-white") }}
+                            {% for error in form.phone.errors %}
+                                <div class="invalid-feedback d-block">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        <div class="d-grid">
+                            {{ form.submit(class="btn btn-primary") }}
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Cursos{% endblock %}
+{% block body_class %}dark-theme{% endblock %}
+
+{% block content %}
+<div class="container py-5 mt-5">
+    <h1 class="text-center section-title">Cursos</h1>
+    <div class="row">
+        {% for course in courses %}
+            <div class="col-md-4 mb-4">
+                <div class="card h-100 shadow" style="background-color:#1e293b; border:none;">
+                    {% if course.image %}
+                        <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="card-img-top" alt="{{ course.title }}">
+                    {% endif %}
+                    <div class="card-body">
+                        <h5 class="card-title">{{ course.title }}</h5>
+                        <p class="card-text">{{ course.description|truncate(150) }}</p>
+                        <a href="{{ url_for('main_bp.course_detail', id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>
+                    </div>
+                </div>
+            </div>
+        {% else %}
+            <p class="text-center">Nenhum curso disponível.</p>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Course and CourseEnrollment models
- create CourseEnrollmentForm
- implement `/cursos` and `/cursos/<int:id>` routes
- create templates for listing courses and viewing a course
- link courses in navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68819b0fb2648324b4b40c8310d4be5a