### PR TITLE
Implement course payment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,10 @@ No painel administrativo existem novas opções para **Cursos** e **Inscrições
 Usuários administradores podem criar, editar e remover cursos, além de
 acompanhar todas as inscrições recebidas.
 
+### Pagamentos
+
+Após se inscrever em um curso o usuário é direcionado para uma página de pagamento.
+O processo é simulado e, quando confirmado, o status da inscrição muda para **paid**
+e é criado um registro em `PaymentTransaction`. Em seguida é apresentado o link de
+acesso ao material configurado para o curso.
 

--- a/admin_routes.py
+++ b/admin_routes.py
@@ -347,6 +347,8 @@ def add_course():
         course = Course(
             title=form.title.data,
             description=form.description.data,
+            price=form.price.data,
+            access_url=form.access_url.data,
             image=filename,
             is_active=form.is_active.data
         )
@@ -365,6 +367,8 @@ def edit_course(id):
     if form.validate_on_submit():
         course.title = form.title.data
         course.description = form.description.data
+        course.price = form.price.data
+        course.access_url = form.access_url.data
         course.is_active = form.is_active.data
         if form.image.data:
             if course.image:

--- a/forms.py
+++ b/forms.py
@@ -106,6 +106,8 @@ class CourseForm(FlaskForm):
     title = StringField('Título', validators=[DataRequired()])
     description = TextAreaField('Descrição', validators=[DataRequired()])
     image = FileField('Imagem', validators=[FileAllowed(['jpg', 'jpeg', 'png'], 'Apenas imagens são permitidas!')])
+    price = FloatField('Preço', validators=[DataRequired()])
+    access_url = StringField('URL de Acesso', validators=[Optional()])
     is_active = BooleanField('Curso Ativo', default=True)
     submit = SubmitField('Salvar')
 
@@ -115,4 +117,8 @@ class CourseEnrollmentForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
     phone = StringField('Telefone', validators=[DataRequired(), Length(min=8, max=20)])
     submit = SubmitField('Enviar Inscrição')
+
+
+class ConfirmPaymentForm(FlaskForm):
+    submit = SubmitField('Confirmar Pagamento')
 

--- a/models.py
+++ b/models.py
@@ -123,6 +123,8 @@ class Course(db.Model):
     title = db.Column(db.String(150), nullable=False)
     description = db.Column(db.Text)
     image = db.Column(db.String(255))
+    price = db.Column(db.Float, default=0.0)
+    access_url = db.Column(db.String(255))
     is_active = db.Column(db.Boolean, default=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -136,9 +138,24 @@ class CourseEnrollment(db.Model):
     name = db.Column(db.String(100), nullable=False)
     email = db.Column(db.String(100), nullable=False)
     phone = db.Column(db.String(20))
+    payment_status = db.Column(db.String(20), default='pending')
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     course = db.relationship('Course', backref=db.backref('enrollments', lazy=True))
+
+
+class PaymentTransaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    enrollment_id = db.Column(db.Integer, db.ForeignKey('course_enrollment.id'), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    provider_id = db.Column(db.String(100))
+    status = db.Column(db.String(20), default='paid')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    enrollment = db.relationship('CourseEnrollment', backref=db.backref('transactions', lazy=True))
+
+    def __repr__(self):
+        return f'<PaymentTransaction {self.id}>'
 
 
 class Convenio(db.Model):

--- a/templates/admin/course_form.html
+++ b/templates/admin/course_form.html
@@ -21,6 +21,20 @@
                 {% endfor %}
             </div>
             <div class="mb-3">
+                {{ form.price.label(class="form-label") }}
+                {{ form.price(class="form-control") }}
+                {% for error in form.price.errors %}
+                    <div class="text-danger"><small>{{ error }}</small></div>
+                {% endfor %}
+            </div>
+            <div class="mb-3">
+                {{ form.access_url.label(class="form-label") }}
+                {{ form.access_url(class="form-control") }}
+                {% for error in form.access_url.errors %}
+                    <div class="text-danger"><small>{{ error }}</small></div>
+                {% endfor %}
+            </div>
+            <div class="mb-3">
                 {{ form.image.label(class="form-label") }}
                 {{ form.image(class="form-control") }}
                 {% if course and course.image %}

--- a/templates/admin/courses.html
+++ b/templates/admin/courses.html
@@ -15,6 +15,7 @@
                 <thead>
                     <tr>
                         <th>Título</th>
+                        <th>Preço</th>
                         <th>Ativo</th>
                         <th>Criado em</th>
                         <th>Ações</th>
@@ -24,6 +25,7 @@
                     {% for course in courses %}
                     <tr>
                         <td>{{ course.title }}</td>
+                        <td>R$ {{ '%.2f'|format(course.price) }}</td>
                         <td>
                             {% if course.is_active %}
                                 <span class="badge bg-success">Ativo</span>

--- a/templates/admin/enrollments.html
+++ b/templates/admin/enrollments.html
@@ -15,6 +15,7 @@
                         <th>Nome</th>
                         <th>Email</th>
                         <th>Telefone</th>
+                        <th>Status</th>
                         <th>Data</th>
                     </tr>
                 </thead>
@@ -25,6 +26,7 @@
                         <td>{{ e.name }}</td>
                         <td>{{ e.email }}</td>
                         <td>{{ e.phone }}</td>
+                        <td>{{ e.payment_status }}</td>
                         <td>{{ e.created_at.strftime('%d/%m/%Y') }}</td>
                     </tr>
                     {% endfor %}

--- a/templates/course_access.html
+++ b/templates/course_access.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Acesso ao Curso{% endblock %}
+{% block body_class %}dark-theme{% endblock %}
+
+{% block content %}
+<div class="container py-5 mt-5">
+    <h1 class="mb-4 text-center">{{ enrollment.course.title }}</h1>
+    {% if enrollment.course.access_url %}
+        <div class="text-center">
+            <a href="{{ enrollment.course.access_url }}" class="btn btn-primary" target="_blank">Acessar Conteúdo</a>
+        </div>
+    {% else %}
+        <p class="text-center text-light">Nenhum link de acesso disponível.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/course_detail.html
+++ b/templates/course_detail.html
@@ -17,6 +17,7 @@
             <div class="card bg-dark-blue shadow border-0">
                 <div class="card-body">
                     <h5 class="card-title mb-3">Inscreva-se</h5>
+                    <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                     <form method="POST">
                         {{ form.csrf_token }}
                         <div class="mb-3">
@@ -43,6 +44,7 @@
                         <div class="d-grid">
                             {{ form.submit(class="btn btn-primary") }}
                         </div>
+                        <p class="text-light mt-2"><small>Você será redirecionado para o pagamento.</small></p>
                     </form>
                 </div>
             </div>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -15,6 +15,7 @@
                     {% endif %}
                     <div class="card-body">
                         <h5 class="card-title">{{ course.title }}</h5>
+                        <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                         <p class="card-text">{{ course.description|truncate(150) }}</p>
                         <a href="{{ url_for('main_bp.course_detail', id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>
                     </div>

--- a/templates/pay_course.html
+++ b/templates/pay_course.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Pagamento{% endblock %}
+{% block body_class %}dark-theme{% endblock %}
+
+{% block content %}
+<div class="container py-5 mt-5">
+    <h1 class="mb-4 text-center">Pagamento do Curso</h1>
+    <p class="text-center text-light">Valor a pagar: R$ {{ '%.2f'|format(enrollment.course.price) }}</p>
+    <div class="text-center mt-4">
+        <form method="POST">
+            {{ form.csrf_token }}
+            <button type="submit" class="btn btn-primary">Confirmar Pagamento</button>
+        </form>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- expand Course model with `price` and `access_url`
- store payment status in CourseEnrollment and record PaymentTransaction
- extend admin to manage price and access URL
- add payment and course access pages
- guide user through payment after enrollment
- document payment flow in README

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6883010ee9088324b46e36be1d202137