### PR TITLE
Add course enrollment tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import app
+from extensions import db
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        yield app.test_client()
+        db.drop_all()
+        db.session.remove()
+
+

--- a/tests/test_courses.py
+++ b/tests/test_courses.py
@@ -1,0 +1,37 @@
+from flask import url_for
+from models import Course, CourseEnrollment
+from extensions import db
+
+
+def create_course(**kwargs):
+    course = Course(**kwargs)
+    db.session.add(course)
+    db.session.commit()
+    return course
+
+
+def test_courses_shows_active_courses(client):
+    with client.application.app_context():
+        active = create_course(title='Active', description='desc', price=10, is_active=True)
+        inactive = create_course(title='Inactive', description='desc', price=10, is_active=False)
+    resp = client.get('/cursos')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Active' in html
+    assert 'Inactive' not in html
+
+
+def test_course_detail_post_creates_enrollment(client):
+    with client.application.app_context():
+        course = create_course(title='Course', description='desc', price=10, is_active=True)
+        url = f'/cursos/{course.id}'
+    data = {'name': 'Test User', 'email': 'test@example.com', 'phone': '12345678'}
+    resp = client.post(url, data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    with client.application.app_context():
+        enrollment = CourseEnrollment.query.first()
+        assert enrollment is not None
+        assert enrollment.name == 'Test User'
+        assert enrollment.email == 'test@example.com'
+        assert enrollment.course_id == course.id
+        assert resp.headers['Location'].endswith(f'/pagamento/{enrollment.id}')


### PR DESCRIPTION
## Summary
- add fixture using in-memory database
- test that active courses render on `/cursos`
- test that valid POST to `/cursos/<id>` creates enrollment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688303f6b69c8324bd3b27a03121930e