### PR TITLE
Add course catalog pages

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -138,6 +138,24 @@ def course_access(enrollment_id):
         return redirect(url_for('main_bp.course_detail', id=enrollment.course_id))
     return render_template('course_access.html', enrollment=enrollment)
 
+
+# Public catalog of courses
+@main_bp.route('/catalogo-cursos')
+def course_catalog():
+    """Display all active courses for visitors."""
+    settings = Settings.query.first()
+    courses = Course.query.filter_by(is_active=True).all()
+    return render_template('course_catalog.html', courses=courses, settings=settings)
+
+
+# Details of a single course without enrollment form
+@main_bp.route('/catalogo-cursos/<int:course_id>')
+def course_catalog_detail(course_id):
+    """Show public details for a course."""
+    course = Course.query.get_or_404(course_id)
+    settings = Settings.query.first()
+    return render_template('course_catalog_detail.html', course=course, settings=settings)
+
 @main_bp.context_processor
 def inject_settings():
     settings = Settings.query.first()

--- a/templates/course_catalog.html
+++ b/templates/course_catalog.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Cursos{% endblock %}
+{% block body_class %}dark-theme{% endblock %}
+
+{% block content %}
+<div class="container py-5 mt-5">
+    <h1 class="text-center section-title">Cursos</h1>
+    <div class="row">
+        {% for course in courses %}
+            <div class="col-md-4 mb-4">
+                <div class="card h-100 shadow" style="background-color:#1e293b; border:none;">
+                    {% if course.image %}
+                        <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="card-img-top" alt="{{ course.title }}">
+                    {% endif %}
+                    <div class="card-body">
+                        <h5 class="card-title">{{ course.title }}</h5>
+                        <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
+                        <p class="card-text">{{ course.description|truncate(150) }}</p>
+                        <a href="{{ url_for('main_bp.course_catalog_detail', course_id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>
+                    </div>
+                </div>
+            </div>
+        {% else %}
+            <p class="text-center">Nenhum curso disponível.</p>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/course_catalog_detail.html
+++ b/templates/course_catalog_detail.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}{{ course.title }}{% endblock %}
+{% block body_class %}dark-theme{% endblock %}
+
+{% block content %}
+<div class="container py-5 mt-5">
+    <div class="row">
+        <div class="col-md-8">
+            <h1 class="mb-4">{{ course.title }}</h1>
+            {% if course.image %}
+                <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="img-fluid mb-4" alt="{{ course.title }}">
+            {% endif %}
+            <div>{{ course.description|safe }}</div>
+        </div>
+        <div class="col-md-4">
+            <div class="card bg-dark-blue shadow border-0">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Informações</h5>
+                    <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
+                    {% if course.access_url %}
+                        <a href="{{ course.access_url }}" class="btn btn-primary" target="_blank">Acessar Conteúdo</a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- show a public catalog of active courses
- allow visitors to view information about a single course

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68867557044c8324bc27ff9d8d26f361