### PR TITLE
Add contact message storage and admin view

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -2,10 +2,10 @@ from flask import Blueprint, render_template, redirect, url_for, flash, current_
 from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.utils import secure_filename
 import os
-from models import GalleryItem, BillingRecord, Invoice, Convenio, Course, CourseEnrollment
+from models import GalleryItem, BillingRecord, Invoice, Convenio, Course, CourseEnrollment, ContactMessage
 from forms import GalleryForm, BillingRecordForm, InvoiceForm, ConvenioForm, CourseForm
 from forms import LoginForm, EventForm, SettingsForm
-from models import db, User, Event, Appointment, Settings, Course, CourseEnrollment
+from models import db, User, Event, Appointment, Settings, Course, CourseEnrollment, ContactMessage
 
 # Create Blueprint for the admin routes
 admin_bp = Blueprint('admin_bp', __name__)
@@ -405,3 +405,10 @@ def delete_course(id):
 def enrollments():
     enrollments = CourseEnrollment.query.order_by(CourseEnrollment.created_at.desc()).all()
     return render_template('admin/enrollments.html', enrollments=enrollments)
+
+
+@admin_bp.route('/messages')
+@login_required
+def messages():
+    messages = ContactMessage.query.order_by(ContactMessage.created_at.desc()).all()
+    return render_template('admin/messages.html', messages=messages)

--- a/models.py
+++ b/models.py
@@ -62,6 +62,18 @@ class Appointment(db.Model):
     def __repr__(self):
         return f'<Appointment {self.name} - {self.date} {self.time}>'
 
+
+class ContactMessage(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    email = db.Column(db.String(120), nullable=False)
+    subject = db.Column(db.String(150), nullable=False)
+    message = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<ContactMessage {self.subject}>'
+
 class Settings(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     site_title = db.Column(db.String(100), default='Dr. Julio Vasconcelos')

--- a/routes.py
+++ b/routes.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, redirect, url_for, flash
 from datetime import datetime
 
 from forms import ContactForm, AppointmentForm, CourseEnrollmentForm, ConfirmPaymentForm
-from models import db, Event, Appointment, Settings, Course, CourseEnrollment, PaymentTransaction
+from models import db, Event, Appointment, Settings, Course, CourseEnrollment, PaymentTransaction, ContactMessage
 
 # Create a Blueprint for the main routes
 main_bp = Blueprint('main_bp', __name__)
@@ -24,13 +24,21 @@ def contact():
     settings = Settings.query.first()
     
     if form.validate_on_submit():
-        # Process contact form submission
+        # Save contact message
+        message = ContactMessage(
+            name=form.name.data,
+            email=form.email.data,
+            subject=form.subject.data,
+            message=form.message.data,
+        )
         try:
+            db.session.add(message)
+            db.session.commit()
             # Send email functionality would go here
-            # For now, just display a success message
             flash('Sua mensagem foi enviada com sucesso! Entraremos em contato em breve.', 'success')
             return redirect(url_for('main_bp.contact'))
         except Exception as e:
+            db.session.rollback()
             flash(f'Ocorreu um erro ao enviar sua mensagem: {str(e)}', 'danger')
             
     return render_template('contact.html', form=form, settings=settings)

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -164,7 +164,7 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                           <a class="nav-link {% if request.endpoint == 'main_bp.contact' %}active{% endif %}" href="{{ url_for('main_bp.contact') }}">
+                           <a class="nav-link {% if request.endpoint == 'admin_bp.messages' %}active{% endif %}" href="{{ url_for('admin_bp.messages') }}">
                                 <i class="fas fa-envelope"></i>
                                 Mensagens
                             </a>

--- a/templates/admin/messages.html
+++ b/templates/admin/messages.html
@@ -1,0 +1,37 @@
+{% extends "admin/base.html" %}
+{% block title %}Mensagens{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Mensagens de Contato</h1>
+</div>
+<div class="card shadow">
+    <div class="card-body">
+        {% if messages %}
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>Nome</th>
+                        <th>Email</th>
+                        <th>Assunto</th>
+                        <th>Data</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for m in messages %}
+                    <tr>
+                        <td>{{ m.name }}</td>
+                        <td>{{ m.email }}</td>
+                        <td>{{ m.subject }}</td>
+                        <td>{{ m.created_at.strftime('%d/%m/%Y') }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-center">Nenhuma mensagem encontrada.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `ContactMessage` model
- store submitted contact form messages
- list contact messages via new admin route
- add admin template for messages
- update sidebar link

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886755b0ef08324b5e24d4e472f0cf7