### PR TITLE
Add course management features

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import os
 
 from config import Config
 from extensions import db  # Correto: db importado do extensions.py
-from models import User, Event, Appointment, Settings
+from models import User, Event, Course, Appointment, Settings
 from forms import LoginForm, AppointmentForm, ContactForm, EventForm, SettingsForm
 from routes import main_bp
 from admin_routes import admin_bp

--- a/forms.py
+++ b/forms.py
@@ -44,6 +44,20 @@ class EventForm(FlaskForm):
     submit = SubmitField('Salvar')
 
 
+class CourseForm(FlaskForm):
+    title = StringField('Título', validators=[DataRequired()])
+    description = TextAreaField('Descrição', validators=[DataRequired()])
+    price = FloatField('Preço', validators=[DataRequired()])
+    start_date = DateField('Data de Início', validators=[DataRequired()])
+    end_date = DateField('Data de Término', validators=[DataRequired()])
+    location = StringField('Local', validators=[DataRequired()])
+    image = FileField('Imagem', validators=[
+        FileAllowed(['jpg', 'png', 'jpeg'], 'Apenas imagens são permitidas!')
+    ])
+    is_active = BooleanField('Curso Ativo', default=True)
+    submit = SubmitField('Salvar')
+
+
 class SettingsForm(FlaskForm):
     site_title = StringField('Título do Site', validators=[DataRequired()])
     contact_email = StringField('Email de Contato', validators=[DataRequired(), Email()])

--- a/migrations/versions/50b7252785e9_create_course_table.py
+++ b/migrations/versions/50b7252785e9_create_course_table.py
@@ -1,0 +1,35 @@
+"""create course table
+
+Revision ID: 50b7252785e9
+Revises: fde92834820f
+Create Date: 2025-07-24 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '50b7252785e9'
+down_revision = 'fde92834820f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'course',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('title', sa.String(length=100), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('price', sa.Float(), nullable=False),
+        sa.Column('start_date', sa.DateTime(), nullable=False),
+        sa.Column('end_date', sa.DateTime(), nullable=False),
+        sa.Column('location', sa.String(length=255), nullable=True),
+        sa.Column('image', sa.String(length=255), nullable=True),
+        sa.Column('is_active', sa.Boolean(), default=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('course')

--- a/models.py
+++ b/models.py
@@ -48,6 +48,18 @@ class Event(db.Model):
             cls.is_active == True
         ).order_by(cls.start_date.desc()).all()
 
+class Course(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(100), nullable=False)
+    description = db.Column(db.Text)
+    price = db.Column(db.Float, nullable=False)
+    start_date = db.Column(db.DateTime, nullable=False)
+    end_date = db.Column(db.DateTime, nullable=False)
+    location = db.Column(db.String(255))
+    image = db.Column(db.String(255))
+    is_active = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
 class Appointment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -153,6 +153,12 @@
                                 Eventos
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint == 'admin_bp.courses' %}active{% endif %}" href="{{ url_for('admin_bp.courses') }}">
+                                <i class="fas fa-graduation-cap"></i>
+                                Cursos
+                            </a>
+                        </li>
                     </ul>
 
                     <div class="sidebar-header mt-4">Conteúdo</div>

--- a/templates/admin/course_form.html
+++ b/templates/admin/course_form.html
@@ -1,0 +1,65 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">{{ title }}</h1>
+<div class="card shadow">
+    <div class="card-body">
+        <form method="POST" enctype="multipart/form-data">
+            {{ form.csrf_token }}
+            <div class="row">
+                <div class="col-md-8 mb-3">
+                    {{ form.title.label(class="form-label") }}
+                    {{ form.title(class="form-control") }}
+                </div>
+                <div class="col-md-4 mb-3">
+                    {{ form.is_active.label(class="form-label d-block") }}
+                    <div class="form-check form-switch">
+                        {{ form.is_active(class="form-check-input") }}
+                        <label class="form-check-label" for="{{ form.is_active.id }}">Curso ativo</label>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    {{ form.start_date.label(class="form-label") }}
+                    {{ form.start_date(class="form-control", type="date") }}
+                </div>
+                <div class="col-md-6 mb-3">
+                    {{ form.end_date.label(class="form-label") }}
+                    {{ form.end_date(class="form-control", type="date") }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    {{ form.price.label(class="form-label") }}
+                    {{ form.price(class="form-control") }}
+                </div>
+                <div class="col-md-6 mb-3">
+                    {{ form.location.label(class="form-label") }}
+                    {{ form.location(class="form-control") }}
+                </div>
+            </div>
+            <div class="mb-3">
+                {{ form.description.label(class="form-label") }}
+                {{ form.description(class="form-control", rows=6) }}
+            </div>
+            <div class="mb-4">
+                {{ form.image.label(class="form-label") }}
+                {{ form.image(class="form-control") }}
+                {% if course and course.image %}
+                    <div class="mt-2">
+                        <p>Imagem atual:</p>
+                        <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="img-thumbnail" style="max-height: 200px;">
+                    </div>
+                {% endif %}
+            </div>
+            <div class="d-flex justify-content-between">
+                <a href="{{ url_for('admin_bp.courses') }}" class="btn btn-secondary">Cancelar</a>
+                {{ form.submit(class="btn btn-primary") }}
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/courses.html
+++ b/templates/admin/courses.html
@@ -1,0 +1,58 @@
+{% extends "admin/base.html" %}
+{% block title %}Cursos{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Gerenciar Cursos</h1>
+    <a href="{{ url_for('admin_bp.add_course') }}" class="btn btn-primary">
+        <i class="fas fa-plus"></i> Novo Curso
+    </a>
+</div>
+
+<div class="card shadow">
+    <div class="card-body">
+        {% if courses %}
+            <div class="table-responsive">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>Título</th>
+                            <th>Preço</th>
+                            <th>Data Início</th>
+                            <th>Data Fim</th>
+                            <th>Local</th>
+                            <th>Status</th>
+                            <th>Ações</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for course in courses %}
+                        <tr>
+                            <td>{{ course.title }}</td>
+                            <td>R$ {{ '%.2f'|format(course.price) }}</td>
+                            <td>{{ course.start_date.strftime('%d/%m/%Y') }}</td>
+                            <td>{{ course.end_date.strftime('%d/%m/%Y') }}</td>
+                            <td>{{ course.location }}</td>
+                            <td>
+                                {% if course.is_active %}
+                                    <span class="badge bg-success">Ativo</span>
+                                {% else %}
+                                    <span class="badge bg-secondary">Inativo</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <a href="{{ url_for('admin_bp.edit_course', id=course.id) }}" class="btn btn-sm btn-outline-primary me-1">
+                                    <i class="fas fa-edit"></i> Editar
+                                </a>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="alert alert-info">Nenhum curso encontrado.</div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `Course` model
- add migration for `course` table
- implement `CourseForm`
- add course management routes
- add admin templates for courses
- link Courses in admin sidebar
- import Course in application setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68819b0d3f8083248827882c67b06542