### PR TITLE
Add public course listing page

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -81,11 +81,18 @@ def events():
                           past_events=past_events)
 
 
-@main_bp.route('/cursos')
+@main_bp.route('/courses')
 def courses():
+    """Public list of active courses."""
     settings = Settings.query.first()
     courses = Course.query.filter_by(is_active=True).all()
     return render_template('courses.html', courses=courses, settings=settings)
+
+
+@main_bp.route('/cursos')
+def cursos():
+    """Portuguese alias for the courses page."""
+    return courses()
 
 
 @main_bp.route('/cursos/<int:id>', methods=['GET', 'POST'])

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -15,6 +15,7 @@
                     {% endif %}
                     <div class="card-body">
                         <h5 class="card-title">{{ course.title }}</h5>
+                        <p class="text-light mb-1">Data: {{ course.created_at.strftime('%d/%m/%Y') }}</p>
                         <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                         <p class="card-text">{{ course.description|truncate(150) }}</p>
                         <a href="{{ url_for('main_bp.course_detail', id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>

--- a/tests/test_courses.py
+++ b/tests/test_courses.py
@@ -21,6 +21,16 @@ def test_courses_shows_active_courses(client):
     assert 'Inactive' not in html
 
 
+def test_courses_route_english_alias(client):
+    """Ensure /courses returns the course list."""
+    with client.application.app_context():
+        create_course(title='Active EN', description='desc', price=10, is_active=True)
+    resp = client.get('/courses')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Active EN' in html
+
+
 def test_course_detail_post_creates_enrollment(client):
     with client.application.app_context():
         course = create_course(title='Course', description='desc', price=10, is_active=True)


### PR DESCRIPTION
## Summary
- add `courses()` view at /courses with alias at /cursos
- display course creation date in courses listing
- test English alias route

## Testing
- `python -m py_compile routes.py tests/test_courses.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688693ecd4648324a63c46fc11b6be8a