### PR TITLE
Save course images to dedicated subfolder

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -343,7 +343,9 @@ def add_course():
         filename = None
         if form.image.data:
             filename = secure_filename(form.image.data.filename)
-            form.image.data.save(os.path.join(current_app.config['UPLOAD_FOLDER'], filename))
+            course_folder = os.path.join(current_app.config['UPLOAD_FOLDER'], 'courses')
+            os.makedirs(course_folder, exist_ok=True)
+            form.image.data.save(os.path.join(course_folder, filename))
         course = Course(
             title=form.title.data,
             description=form.description.data,
@@ -373,11 +375,13 @@ def edit_course(id):
         if form.image.data:
             if course.image:
                 try:
-                    os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], course.image))
+                    os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], 'courses', course.image))
                 except Exception:
                     pass
             filename = secure_filename(form.image.data.filename)
-            form.image.data.save(os.path.join(current_app.config['UPLOAD_FOLDER'], filename))
+            course_folder = os.path.join(current_app.config['UPLOAD_FOLDER'], 'courses')
+            os.makedirs(course_folder, exist_ok=True)
+            form.image.data.save(os.path.join(course_folder, filename))
             course.image = filename
         db.session.commit()
         flash('Curso atualizado!', 'success')
@@ -391,7 +395,7 @@ def delete_course(id):
     course = Course.query.get_or_404(id)
     if course.image:
         try:
-            os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], course.image))
+            os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], 'courses', course.image))
         except Exception:
             pass
     db.session.delete(course)

--- a/templates/admin/course_form.html
+++ b/templates/admin/course_form.html
@@ -39,7 +39,7 @@
                 {{ form.image(class="form-control") }}
                 {% if course and course.image %}
                     <div class="mt-2">
-                        <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="img-thumbnail" style="max-height:200px;" alt="{{ course.title }}">
+                        <img src="{{ url_for('static', filename='uploads/courses/' + course.image) }}" class="img-thumbnail" style="max-height:200px;" alt="{{ course.title }}">
                     </div>
                 {% endif %}
             </div>

--- a/templates/course_catalog.html
+++ b/templates/course_catalog.html
@@ -11,7 +11,7 @@
             <div class="col-md-4 mb-4">
                 <div class="card h-100 shadow" style="background-color:#1e293b; border:none;">
                     {% if course.image %}
-                        <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="card-img-top" alt="{{ course.title }}">
+                        <img src="{{ url_for('static', filename='uploads/courses/' + course.image) }}" class="card-img-top" alt="{{ course.title }}">
                     {% endif %}
                     <div class="card-body">
                         <h5 class="card-title">{{ course.title }}</h5>

--- a/templates/course_catalog_detail.html
+++ b/templates/course_catalog_detail.html
@@ -9,7 +9,7 @@
         <div class="col-md-8">
             <h1 class="mb-4">{{ course.title }}</h1>
             {% if course.image %}
-                <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="img-fluid mb-4" alt="{{ course.title }}">
+                <img src="{{ url_for('static', filename='uploads/courses/' + course.image) }}" class="img-fluid mb-4" alt="{{ course.title }}">
             {% endif %}
             <div>{{ course.description|safe }}</div>
         </div>

--- a/templates/course_detail.html
+++ b/templates/course_detail.html
@@ -9,7 +9,7 @@
         <div class="col-md-8">
             <h1 class="mb-4">{{ course.title }}</h1>
             {% if course.image %}
-                <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="img-fluid mb-4" alt="{{ course.title }}">
+                <img src="{{ url_for('static', filename='uploads/courses/' + course.image) }}" class="img-fluid mb-4" alt="{{ course.title }}">
             {% endif %}
             <div>{{ course.description|safe }}</div>
         </div>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -11,7 +11,7 @@
             <div class="col-md-4 mb-4">
                 <div class="card h-100 shadow" style="background-color:#1e293b; border:none;">
                     {% if course.image %}
-                        <img src="{{ url_for('static', filename='uploads/' + course.image) }}" class="card-img-top" alt="{{ course.title }}">
+                        <img src="{{ url_for('static', filename='uploads/courses/' + course.image) }}" class="card-img-top" alt="{{ course.title }}">
                     {% endif %}
                     <div class="card-body">
                         <h5 class="card-title">{{ course.title }}</h5>


### PR DESCRIPTION
## Summary
- ensure course images are stored under `static/uploads/courses`
- show course images from that subfolder in templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688697db2b888324ab9d28c856b1680d