### PR TITLE
Initial course detail and registration pages

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -126,3 +126,10 @@ class CourseEnrollmentForm(FlaskForm):
 class ConfirmPaymentForm(FlaskForm):
     submit = SubmitField('Confirmar Pagamento')
 
+
+class RegistrationForm(FlaskForm):
+    """Simple form to register interest in a course."""
+    name = StringField('Nome', validators=[DataRequired(), Length(min=3, max=100)])
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    submit = SubmitField('Inscreva-se')
+

--- a/routes.py
+++ b/routes.py
@@ -1,7 +1,13 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, current_app, request
 from datetime import datetime
 
-from forms import ContactForm, AppointmentForm, CourseEnrollmentForm, ConfirmPaymentForm
+from forms import (
+    ContactForm,
+    AppointmentForm,
+    CourseEnrollmentForm,
+    ConfirmPaymentForm,
+    RegistrationForm,
+)
 from models import db, Event, Appointment, Settings, Course, CourseEnrollment, PaymentTransaction, CoursePurchase
 
 try:
@@ -95,6 +101,18 @@ def cursos():
     return courses()
 
 
+@main_bp.route('/courses/<int:id>', methods=['GET', 'POST'])
+def course_page(id):
+    """Display a single course with a simple registration form."""
+    course = Course.query.get_or_404(id)
+    settings = Settings.query.first()
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        flash('Inscrição registrada com sucesso!', 'success')
+        return redirect(url_for('main_bp.course_page', id=id))
+    return render_template('course_detail.html', course=course, form=form, settings=settings)
+
+
 @main_bp.route('/cursos/<int:id>', methods=['GET', 'POST'])
 def course_detail(id):
     course = Course.query.get_or_404(id)
@@ -115,7 +133,7 @@ def course_detail(id):
         except Exception as e:
             db.session.rollback()
             flash(f'Ocorreu um erro ao registrar sua inscrição: {e}', 'danger')
-    return render_template('course_detail.html', course=course, form=form, settings=settings)
+    return render_template('course_enrollment.html', course=course, form=form, settings=settings)
 
 
 @main_bp.route('/pagamento/<int:enrollment_id>', methods=['GET', 'POST'])

--- a/templates/course_enrollment.html
+++ b/templates/course_enrollment.html
@@ -16,8 +16,7 @@
         <div class="col-md-4">
             <div class="card bg-dark-blue shadow border-0">
                 <div class="card-body">
-                    <h5 class="card-title mb-3">Informações</h5>
-                    <p class="text-light mb-1">Data: {{ course.created_at.strftime('%d/%m/%Y') }}</p>
+                    <h5 class="card-title mb-3">Inscreva-se</h5>
                     <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                     <form method="POST">
                         {{ form.csrf_token }}
@@ -35,9 +34,17 @@
                                 <div class="invalid-feedback d-block">{{ error }}</div>
                             {% endfor %}
                         </div>
+                        <div class="mb-3">
+                            {{ form.phone.label(class="form-label text-light") }}
+                            {{ form.phone(class="form-control bg-darker text-white") }}
+                            {% for error in form.phone.errors %}
+                                <div class="invalid-feedback d-block">{{ error }}</div>
+                            {% endfor %}
+                        </div>
                         <div class="d-grid">
                             {{ form.submit(class="btn btn-primary") }}
                         </div>
+                        <p class="text-light mt-2"><small>Você será redirecionado para o pagamento.</small></p>
                     </form>
                 </div>
             </div>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -18,7 +18,7 @@
                         <p class="text-light mb-1">Data: {{ course.created_at.strftime('%d/%m/%Y') }}</p>
                         <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                         <p class="card-text">{{ course.description|truncate(150) }}</p>
-                        <a href="{{ url_for('main_bp.course_detail', id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>
+                        <a href="{{ url_for('main_bp.course_page', id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add `RegistrationForm` to allow interested visitors to sign up
- provide `/courses/<id>` route with minimal registration flow
- rename old `course_detail.html` to `course_enrollment.html`
- create new `course_detail.html` for the public course page
- link course listing to the new route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688699a006a883249efd22c5119c6e7c