### PR TITLE
Implement contact messages management

### DIFF
--- a/models.py
+++ b/models.py
@@ -61,6 +61,18 @@ class Appointment(db.Model):
     def __repr__(self):
         return f'<Appointment {self.name} - {self.date} {self.time}>'
 
+
+class ContactMessage(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    email = db.Column(db.String(100), nullable=False)
+    subject = db.Column(db.String(150), nullable=False)
+    message = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<ContactMessage {self.name}>'
+
 class Settings(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     site_title = db.Column(db.String(100), default='Dr. Julio Vasconcelos')

--- a/routes.py
+++ b/routes.py
@@ -8,7 +8,17 @@ from forms import (
     ConfirmPaymentForm,
     RegistrationForm,
 )
-from models import db, Event, Appointment, Settings, Course, CourseEnrollment, PaymentTransaction, CoursePurchase
+from models import (
+    db,
+    Event,
+    Appointment,
+    Settings,
+    Course,
+    CourseEnrollment,
+    PaymentTransaction,
+    CoursePurchase,
+    ContactMessage,
+)
 
 try:
     import stripe
@@ -33,15 +43,24 @@ def about():
 def contact():
     form = ContactForm()
     settings = Settings.query.first()
-    
+
     if form.validate_on_submit():
-        # Process contact form submission
+        message = ContactMessage(
+            name=form.name.data,
+            email=form.email.data,
+            subject=form.subject.data,
+            message=form.message.data,
+        )
         try:
+            db.session.add(message)
+            db.session.commit()
+
             # Send email functionality would go here
-            # For now, just display a success message
+
             flash('Sua mensagem foi enviada com sucesso! Entraremos em contato em breve.', 'success')
             return redirect(url_for('main_bp.contact'))
         except Exception as e:
+            db.session.rollback()
             flash(f'Ocorreu um erro ao enviar sua mensagem: {str(e)}', 'danger')
             
     return render_template('contact.html', form=form, settings=settings)

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -164,7 +164,7 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                           <a class="nav-link {% if request.endpoint == 'main_bp.contact' %}active{% endif %}" href="{{ url_for('main_bp.contact') }}">
+                           <a class="nav-link {% if request.endpoint == 'admin_bp.messages' %}active{% endif %}" href="{{ url_for('admin_bp.messages') }}">
                                 <i class="fas fa-envelope"></i>
                                 Mensagens
                             </a>

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -116,7 +116,7 @@
             <div class="card shadow mb-4">
                 <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
                     <h6 class="m-0 font-weight-bold text-primary">Mensagens Recentes</h6>
-                    <a href="{{ url_for('main_bp.contact') }}" class="btn btn-sm btn-primary">Ver Todas</a>
+                    <a href="{{ url_for('admin_bp.messages') }}" class="btn btn-sm btn-primary">Ver Todas</a>
                 </div>
                 <div class="card-body">
                     {% if recent_contacts %}

--- a/templates/admin/messages.html
+++ b/templates/admin/messages.html
@@ -1,0 +1,43 @@
+{% extends "admin/base.html" %}
+{% block title %}Mensagens{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Mensagens de Contato</h1>
+</div>
+<div class="card shadow">
+    <div class="card-body">
+        {% if messages %}
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>Nome</th>
+                        <th>Email</th>
+                        <th>Assunto</th>
+                        <th>Data</th>
+                        <th>Ações</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for m in messages %}
+                    <tr>
+                        <td>{{ m.name }}</td>
+                        <td>{{ m.email }}</td>
+                        <td>{{ m.subject }}</td>
+                        <td>{{ m.created_at.strftime('%d/%m/%Y') }}</td>
+                        <td>
+                            <form method="post" action="{{ url_for('admin_bp.delete_message', id=m.id) }}" class="d-inline" onsubmit="return confirm('Excluir esta mensagem?');">
+                                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-center">Nenhuma mensagem encontrada.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `ContactMessage` model for storing contact form submissions
- save contact form data in the `/contact` route
- list and delete messages via new admin routes
- display message metrics on dashboard and link to new messages page
- add admin template to show messages and update sidebar link

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886b10468088324818414e43a717435