### PR TITLE
Add active courses list route

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -114,6 +114,16 @@ def courses():
     return render_template('courses.html', courses=courses, settings=settings)
 
 
+# New route listing active courses ordered by start_date
+@main_bp.route('/active-courses')
+def active_courses():
+    """List active courses ordered by start_date if available."""
+    settings = Settings.query.first()
+    order_field = getattr(Course, 'start_date', Course.created_at)
+    courses = Course.query.filter_by(is_active=True).order_by(order_field).all()
+    return render_template('courses.html', courses=courses, settings=settings)
+
+
 @main_bp.route('/cursos')
 def cursos():
     """Portuguese alias for the courses page."""

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
                         <a class="nav-link" href="{{ url_for('main_bp.events') }}">Eventos</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('main_bp.courses') }}">Cursos</a>
+                        <a class="nav-link" href="{{ url_for('main_bp.active_courses') }}">Cursos</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('main_bp.appointment') }}">Agendar Consulta</a>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -15,7 +15,11 @@
                     {% endif %}
                     <div class="card-body">
                         <h5 class="card-title">{{ course.title }}</h5>
+                        {% if course.start_date %}
+                        <p class="text-light mb-1">Início: {{ course.start_date.strftime('%d/%m/%Y') }}</p>
+                        {% else %}
                         <p class="text-light mb-1">Data: {{ course.created_at.strftime('%d/%m/%Y') }}</p>
+                        {% endif %}
                         <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                         <p class="card-text">{{ course.description|truncate(150) }}</p>
                         <a href="{{ url_for('main_bp.course_page', id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>


### PR DESCRIPTION
## Summary
- show active courses sorted by start date
- update navigation to link to new route
- display course start date in list when available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886b516f3b0832495a63eb5eb7e4dce