### PR TITLE
Implement course date helpers

### DIFF
--- a/models.py
+++ b/models.py
@@ -142,6 +142,28 @@ class Course(db.Model):
     def __repr__(self):
         return f'<Course {self.title}>'
 
+    @classmethod
+    def get_upcoming_courses(cls):
+        """Return active courses starting today or later if start_date exists."""
+        query = cls.query.filter(cls.is_active == True)
+        if hasattr(cls, "start_date"):
+            query = query.filter(cls.start_date >= datetime.utcnow())
+            order_field = cls.start_date
+        else:
+            order_field = cls.created_at
+        return query.order_by(order_field).all()
+
+    @classmethod
+    def get_past_courses(cls):
+        """Return active courses that have ended when date fields exist."""
+        if not hasattr(cls, "end_date"):
+            return []
+        query = cls.query.filter(
+            cls.end_date < datetime.utcnow(), cls.is_active == True
+        )
+        order_field = getattr(cls, "start_date", cls.created_at).desc()
+        return query.order_by(order_field).all()
+
 
 class CourseEnrollment(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/routes.py
+++ b/routes.py
@@ -117,10 +117,9 @@ def courses():
 # New route listing active courses ordered by start_date
 @main_bp.route('/active-courses')
 def active_courses():
-    """List active courses ordered by start_date if available."""
+    """List upcoming courses using Course helper methods."""
     settings = Settings.query.first()
-    order_field = getattr(Course, 'start_date', Course.created_at)
-    courses = Course.query.filter_by(is_active=True).order_by(order_field).all()
+    courses = Course.get_upcoming_courses()
     return render_template('courses.html', courses=courses, settings=settings)
 
 


### PR DESCRIPTION
## Summary
- add helpers for upcoming and past courses in `Course`
- use new helper in public `active_courses` route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886b60db0548324ad1ce8f0711fd467