### PR TITLE
Save course images in dedicated uploads folder

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -364,7 +364,7 @@ def add_course():
         filename = None
         if form.image.data:
             filename = secure_filename(form.image.data.filename)
-            course_folder = os.path.join(current_app.config['UPLOAD_FOLDER'], 'courses')
+            course_folder = os.path.join(current_app.root_path, 'static', 'uploads', 'courses')
             os.makedirs(course_folder, exist_ok=True)
             form.image.data.save(os.path.join(course_folder, filename))
         course = Course(
@@ -396,11 +396,11 @@ def edit_course(id):
         if form.image.data:
             if course.image:
                 try:
-                    os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], 'courses', course.image))
+                    os.remove(os.path.join(current_app.root_path, 'static', 'uploads', 'courses', course.image))
                 except Exception:
                     pass
             filename = secure_filename(form.image.data.filename)
-            course_folder = os.path.join(current_app.config['UPLOAD_FOLDER'], 'courses')
+            course_folder = os.path.join(current_app.root_path, 'static', 'uploads', 'courses')
             os.makedirs(course_folder, exist_ok=True)
             form.image.data.save(os.path.join(course_folder, filename))
             course.image = filename
@@ -416,7 +416,7 @@ def delete_course(id):
     course = Course.query.get_or_404(id)
     if course.image:
         try:
-            os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], 'courses', course.image))
+            os.remove(os.path.join(current_app.root_path, 'static', 'uploads', 'courses', course.image))
         except Exception:
             pass
     db.session.delete(course)

--- a/app.py
+++ b/app.py
@@ -56,6 +56,8 @@ def create_initial_data():
 if __name__ == '__main__':
     uploads_path = os.path.join(app.root_path, 'static', 'uploads')
     os.makedirs(uploads_path, exist_ok=True)
+    courses_path = os.path.join(uploads_path, 'courses')
+    os.makedirs(courses_path, exist_ok=True)
 
     create_initial_data()  # ✅ Só executa quando rodar diretamente (não em flask db ...)
     app.run(debug=True)

--- a/run.py
+++ b/run.py
@@ -7,6 +7,9 @@ if __name__ == '__main__':
     uploads_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'uploads')
     if not os.path.exists(uploads_dir):
         os.makedirs(uploads_dir)
+    courses_dir = os.path.join(uploads_dir, 'courses')
+    if not os.path.exists(courses_dir):
+        os.makedirs(courses_dir)
         
     # Run the application
     app.run(debug=True, host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- ensure course uploads go to `static/uploads/courses`
- create the folder at startup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886b766ae6c8324aeb6c1302910fd59