### PR TITLE
Add sorted courses route and update templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,15 @@ Não existem variáveis específicas para cursos ou pagamentos até o momento.
 
 ## Cursos
 
-Os cursos disponíveis são exibidos na página `/cursos`. Cada curso tem uma
-página de detalhes onde o visitante pode se inscrever informando nome, e‑mail e
+Os cursos disponíveis são exibidos na página `/cursos` (ou `/courses` em inglês).
+Cada curso tem uma página de detalhes onde o visitante pode se inscrever informando nome, e‑mail e
 telefone. Após o envio, a inscrição é registrada no banco de dados.
+
+Para visualizar a lista de cursos basta iniciar a aplicação e acessar:
+
+```
+http://localhost:5000/courses
+```
 O cadastro de cursos é representado pelo modelo `Course`, que armazena título,
 descrição, imagem, preço, link de acesso e se o curso está ativo.
 

--- a/routes.py
+++ b/routes.py
@@ -108,9 +108,14 @@ def events():
 
 @main_bp.route('/courses')
 def courses():
-    """Public list of active courses."""
+    """List active courses ordered by start date if available."""
     settings = Settings.query.first()
-    courses = Course.query.filter_by(is_active=True).all()
+    order_field = getattr(Course, 'start_date', Course.created_at)
+    courses = (
+        Course.query.filter_by(is_active=True)
+        .order_by(order_field)
+        .all()
+    )
     return render_template('courses.html', courses=courses, settings=settings)
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
                         <a class="nav-link" href="{{ url_for('main_bp.events') }}">Eventos</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('main_bp.active_courses') }}">Cursos</a>
+                        <a class="nav-link" href="{{ url_for('main_bp.courses') }}">Cursos</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('main_bp.appointment') }}">Agendar Consulta</a>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -16,13 +16,40 @@
                     <div class="card-body">
                         <h5 class="card-title">{{ course.title }}</h5>
                         {% if course.start_date %}
-                        <p class="text-light mb-1">Início: {{ course.start_date.strftime('%d/%m/%Y') }}</p>
-                        {% else %}
-                        <p class="text-light mb-1">Data: {{ course.created_at.strftime('%d/%m/%Y') }}</p>
+                            <p class="text-light mb-1">
+                                <i class="far fa-calendar-alt me-2"></i> {{ course.start_date.strftime('%d/%m/%Y') }}
+                            </p>
                         {% endif %}
-                        <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
-                        <p class="card-text">{{ course.description|truncate(150) }}</p>
-                        <a href="{{ url_for('main_bp.course_page', id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>
+                        <p class="text-light">
+                            <i class="fas fa-money-bill-wave me-2"></i> R$ {{ '%.2f'|format(course.price) }}
+                        </p>
+                        <p class="card-text">{{ course.description|truncate(200) }}</p>
+                        <button type="button" class="btn btn-consult" data-bs-toggle="modal" data-bs-target="#courseModal{{ course.id }}">
+                            Ver Detalhes
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Course Modal -->
+            <div class="modal fade" id="courseModal{{ course.id }}" tabindex="-1" aria-labelledby="courseModalLabel{{ course.id }}" aria-hidden="true">
+                <div class="modal-dialog modal-lg">
+                    <div class="modal-content" style="background-color:#1e293b; color:white;">
+                        <div class="modal-header" style="border-bottom-color:#2d3748;">
+                            <h5 class="modal-title" id="courseModalLabel{{ course.id }}">{{ course.title }}</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            {% if course.image %}
+                                <img src="{{ url_for('static', filename='uploads/courses/' + course.image) }}" class="img-fluid mb-3 w-100" alt="{{ course.title }}">
+                            {% endif %}
+                            <p><strong>Valor:</strong> R$ {{ '%.2f'|format(course.price) }}</p>
+                            <div>{{ course.description|safe }}</div>
+                        </div>
+                        <div class="modal-footer" style="border-top-color:#2d3748;">
+                            <a href="{{ url_for('main_bp.course_page', id=course.id) }}" class="btn btn-primary">Inscrever-se</a>
+                            <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Fechar</button>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- order courses by start_date in `/courses` route
- revamp `courses.html` template to match events layout with modal details
- link courses page from the navigation bar
- document how to view courses

## Testing
- `pytest -q` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886c85488808324bfa4eec518617532