### PR TITLE
Add courses listing route and template

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -106,16 +106,16 @@ def events():
                           past_events=past_events)
 
 
-@main_bp.route('/courses')
-def courses():
-    """List active courses ordered by start date if available."""
+@main_bp.route('/courses', endpoint='courses')
+def list_courses():
+    """List active courses ordered by start date when available."""
     settings = Settings.query.first()
-    order_field = getattr(Course, 'start_date', Course.created_at)
-    courses = (
-        Course.query.filter_by(is_active=True)
-        .order_by(order_field)
-        .all()
-    )
+    query = Course.query.filter_by(is_active=True)
+    if hasattr(Course, "start_date"):
+        query = query.order_by(Course.start_date)
+    else:
+        query = query.order_by(Course.created_at)
+    courses = query.all()
     return render_template('courses.html', courses=courses, settings=settings)
 
 
@@ -131,7 +131,7 @@ def active_courses():
 @main_bp.route('/cursos')
 def cursos():
     """Portuguese alias for the courses page."""
-    return courses()
+    return list_courses()
 
 
 @main_bp.route('/courses/<int:id>', methods=['GET', 'POST'])

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -54,7 +54,7 @@
                 </div>
             </div>
         {% else %}
-            <p class="text-center">Nenhum curso disponível.</p>
+            <p class="text-center">Nenhum curso ativo disponível.</p>
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add route `list_courses` for `/courses`
- show 'Nenhum curso ativo disponível' in courses page when none found

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886d10cb0b08324adacd6e74cdd8cba