### PR TITLE
Ensure initial data is created on run

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,16 @@ python run.py
 ```
 
 Isso criará a pasta `static/uploads` caso não exista e rodará o servidor em `http://localhost:5000`.
+Na primeira execução o script também cria automaticamente um usuário administrador e configurações iniciais.
 
 Para produção é possível utilizar o `Procfile` com Gunicorn. O arquivo `runtime.txt` define a versão do Python.
 
 ### Migrações
 
 
-As migrações do banco ficam na pasta `migrations/`. Com o ambiente virtual ativo e a variável `FLASK_APP` apontando para `app.py`, gere uma nova migração sempre que modificar os modelos e aplique-a:
+As migrações do banco ficam na pasta `migrations/`.
+Depois de clonar o projeto execute `flask db upgrade` para criar todas as tabelas.
+Com o ambiente virtual ativo e `FLASK_APP` apontando para `app.py`, gere uma nova migração sempre que modificar os modelos e aplique-a:
 
 ```bash
 export FLASK_APP=app.py

--- a/run.py
+++ b/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from app import app
+from app import app, create_initial_data
 import os
 
 if __name__ == '__main__':
@@ -11,5 +11,8 @@ if __name__ == '__main__':
     if not os.path.exists(courses_dir):
         os.makedirs(courses_dir)
         
+    # Initialize default data (admin user and settings)
+    create_initial_data()
+
     # Run the application
     app.run(debug=True, host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- initialize admin user and settings automatically in `run.py`
- document automatic initial data creation
- clarify how to apply migrations when starting from a fresh clone

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886d53e07488324a13aaae336f17bf7