### PR TITLE
Improve image deletion error handling

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -161,7 +161,7 @@ def edit_event(id):
                 # Delete old image
                 try:
                     os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], event.image))
-                except:
+                except FileNotFoundError:
                     pass
                     
             filename = secure_filename(form.image.data.filename)
@@ -231,7 +231,7 @@ def edit_course(id):
             if course.image:
                 try:
                     os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], course.image))
-                except:
+                except FileNotFoundError:
                     pass
             filename = secure_filename(form.image.data.filename)
             form.image.data.save(os.path.join(current_app.config['UPLOAD_FOLDER'], filename))


### PR DESCRIPTION
## Summary
- avoid bare except blocks when deleting event images
- avoid bare except blocks when deleting course images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886e6658ce88324b3905c258c84bc8e