### PR TITLE
Add student role and student area with role-based routing

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, current_app
-from flask_login import login_user, logout_user, login_required, current_user
+from flask_login import login_user, logout_user, current_user
+from functools import wraps
 from werkzeug.utils import secure_filename
 import os
 from models import (
@@ -29,21 +30,35 @@ from models import (
 # Create Blueprint for the admin routes
 admin_bp = Blueprint('admin_bp', __name__)
 
+
+def admin_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if not current_user.is_authenticated or current_user.role != 'admin':
+            return redirect(url_for('admin_bp.login'))
+        return f(*args, **kwargs)
+    return decorated_function
+
+
 @admin_bp.route('/login', methods=['GET', 'POST'])
 def login():
     if current_user.is_authenticated:
-        return redirect(url_for('admin_bp.dashboard'))
-    
+        if current_user.role == 'admin':
+            return redirect(url_for('admin_bp.dashboard'))
+        return redirect(url_for('student_bp.dashboard'))
+
     form = LoginForm()
     if form.validate_on_submit():
         user = User.query.filter_by(username=form.username.data).first()
         if user is None or not user.check_password(form.password.data):
             flash('Usuário ou senha inválidos', 'danger')
             return redirect(url_for('admin_bp.login'))
-            
+
         login_user(user, remember=form.remember_me.data)
-        return redirect(url_for('admin_bp.dashboard'))
-        
+        if user.role == 'admin':
+            return redirect(url_for('admin_bp.dashboard'))
+        return redirect(url_for('student_bp.dashboard'))
+
     return render_template('admin/login.html', form=form)
 
 @admin_bp.route('/logout')
@@ -52,7 +67,7 @@ def logout():
     return redirect(url_for('main_bp.index'))
 
 @admin_bp.route('/')
-@login_required
+@admin_required
 def dashboard():
     # Get recent appointments
     appointments = Appointment.query.order_by(Appointment.created_at.desc()).limit(5).all()
@@ -70,13 +85,13 @@ def dashboard():
                           recent_contacts=recent_contacts)
 
 @admin_bp.route('/appointments')
-@login_required
+@admin_required
 def appointments():
     appointments = Appointment.query.order_by(Appointment.date.desc()).all()
     return render_template('admin/appointments.html', appointments=appointments)
 
 @admin_bp.route('/appointment/<int:id>/status/<status>')
-@login_required
+@admin_required
 def update_appointment_status(id, status):
     appointment = Appointment.query.get_or_404(id)
     
@@ -90,13 +105,13 @@ def update_appointment_status(id, status):
     return redirect(url_for('admin_bp.appointments'))
 
 @admin_bp.route('/events')
-@login_required
+@admin_required
 def events():
     events = Event.query.order_by(Event.start_date.desc()).all()
     return render_template('admin/events.html', events=events)
 
 @admin_bp.route('/events/add', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def add_event():
     form = EventForm()
     
@@ -124,7 +139,7 @@ def add_event():
     return render_template('admin/event_form.html', form=form, title='Adicionar Evento')
 
 @admin_bp.route('/events/edit/<int:id>', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def edit_event(id):
     event = Event.query.get_or_404(id)
     form = EventForm(obj=event)
@@ -156,7 +171,7 @@ def edit_event(id):
     return render_template('admin/event_form.html', form=form, title='Editar Evento')
 
 @admin_bp.route('/settings', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def settings():
     settings = Settings.query.first()
     if not settings:
@@ -183,7 +198,7 @@ def settings():
     return render_template('admin/settings.html', form=form, settings=settings)
 
 @admin_bp.route('/gallery', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def gallery():
     form = GalleryForm()
     items = GalleryItem.query.order_by(GalleryItem.created_at.desc()).all()
@@ -213,7 +228,7 @@ def gallery():
 
 
 @admin_bp.route('/gallery/delete/<int:item_id>', methods=['POST'])
-@login_required
+@admin_required
 def delete_gallery_item(item_id):
     item = GalleryItem.query.get_or_404(item_id)
     gallery_folder = os.path.join(current_app.config['UPLOAD_FOLDER'], 'gallery')
@@ -232,14 +247,14 @@ def delete_gallery_item(item_id):
 
 
 @admin_bp.route('/billings')
-@login_required
+@admin_required
 def billings():
     records = BillingRecord.query.order_by(BillingRecord.created_at.desc()).all()
     return render_template('admin/billings.html', records=records)
 
 
 @admin_bp.route('/billings/add', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def add_billing():
     form = BillingRecordForm()
     if form.validate_on_submit():
@@ -257,7 +272,7 @@ def add_billing():
 
 
 @admin_bp.route('/billings/edit/<int:id>', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def edit_billing(id):
     record = BillingRecord.query.get_or_404(id)
     form = BillingRecordForm(obj=record)
@@ -273,14 +288,14 @@ def edit_billing(id):
 
 
 @admin_bp.route('/invoices')
-@login_required
+@admin_required
 def invoices():
     invoices = Invoice.query.order_by(Invoice.created_at.desc()).all()
     return render_template('admin/invoices.html', invoices=invoices)
 
 
 @admin_bp.route('/invoices/add', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def add_invoice():
     form = InvoiceForm()
     if form.validate_on_submit():
@@ -298,7 +313,7 @@ def add_invoice():
 
 
 @admin_bp.route('/invoices/edit/<int:id>', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def edit_invoice(id):
     invoice = Invoice.query.get_or_404(id)
     form = InvoiceForm(obj=invoice)
@@ -314,14 +329,14 @@ def edit_invoice(id):
 
 
 @admin_bp.route('/convenios')
-@login_required
+@admin_required
 def convenios():
     convenios = Convenio.query.order_by(Convenio.created_at.desc()).all()
     return render_template('admin/convenios.html', convenios=convenios)
 
 
 @admin_bp.route('/convenios/add', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def add_convenio():
     form = ConvenioForm()
     if form.validate_on_submit():
@@ -338,7 +353,7 @@ def add_convenio():
 
 
 @admin_bp.route('/convenios/edit/<int:id>', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def edit_convenio(id):
     convenio = Convenio.query.get_or_404(id)
     form = ConvenioForm(obj=convenio)
@@ -353,14 +368,14 @@ def edit_convenio(id):
 
 
 @admin_bp.route('/courses')
-@login_required
+@admin_required
 def courses():
     courses = Course.query.order_by(Course.created_at.desc()).all()
     return render_template('admin/courses.html', courses=courses)
 
 
 @admin_bp.route('/courses/add', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def add_course():
     form = CourseForm()
     if form.validate_on_submit():
@@ -386,7 +401,7 @@ def add_course():
 
 
 @admin_bp.route('/courses/edit/<int:id>', methods=['GET', 'POST'])
-@login_required
+@admin_required
 def edit_course(id):
     course = Course.query.get_or_404(id)
     form = CourseForm(obj=course)
@@ -414,7 +429,7 @@ def edit_course(id):
 
 
 @admin_bp.route('/courses/delete/<int:id>', methods=['POST'])
-@login_required
+@admin_required
 def delete_course(id):
     course = Course.query.get_or_404(id)
     if course.image:
@@ -429,28 +444,28 @@ def delete_course(id):
 
 
 @admin_bp.route('/enrollments')
-@login_required
+@admin_required
 def enrollments():
     enrollments = CourseEnrollment.query.order_by(CourseEnrollment.created_at.desc()).all()
     return render_template('admin/enrollments.html', enrollments=enrollments)
 
 
 @admin_bp.route('/registrations')
-@login_required
+@admin_required
 def registrations():
     regs = CourseRegistration.query.order_by(CourseRegistration.created_at.desc()).all()
     return render_template('admin/registrations.html', registrations=regs)
 
 
 @admin_bp.route('/messages')
-@login_required
+@admin_required
 def messages():
     messages = ContactMessage.query.order_by(ContactMessage.created_at.desc()).all()
     return render_template('admin/messages.html', messages=messages)
 
 
 @admin_bp.route('/messages/<int:id>/delete', methods=['POST'])
-@login_required
+@admin_required
 def delete_message(id):
     message = ContactMessage.query.get_or_404(id)
     db.session.delete(message)

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from extensions import db  # Correto: db importado do extensions.py
 from models import User, Event, Appointment, Settings
 from routes import main_bp
 from admin_routes import admin_bp
+from student_routes import student_bp
 
 # Create Flask application
 app = Flask(__name__)
@@ -18,12 +19,13 @@ app.config.from_object(Config)
 db.init_app(app)
 migrate = Migrate(app, db)
 login_manager = LoginManager(app)
-login_manager.login_view = 'admin_bp.login'
+login_manager.login_view = 'student_bp.login'
 mail = Mail(app)
 
 # Register blueprints
 app.register_blueprint(main_bp)
 app.register_blueprint(admin_bp, url_prefix='/admin')
+app.register_blueprint(student_bp, url_prefix='/aluno')
 
 # Flask-Login: Carregador de usuário
 @login_manager.user_loader
@@ -35,7 +37,7 @@ def create_initial_data():
     with app.app_context():
         db.create_all()
         if not User.query.filter_by(username='admin').first():
-            user = User(username='admin', email='admin@example.com')
+            user = User(username='admin', email='admin@example.com', role='admin')
             user.set_password('admin123')
             db.session.add(user)
 

--- a/create_admin.py
+++ b/create_admin.py
@@ -5,7 +5,7 @@ with app.app_context():
     db.create_all()
     admin = User.query.filter_by(username="admin").first()
     if not admin:
-        admin = User(username="admin", email="admin@drjulio.com")
+        admin = User(username="admin", email="admin@drjulio.com", role='admin')
         admin.set_password("12345678")
         db.session.add(admin)
         db.session.commit()

--- a/forms.py
+++ b/forms.py
@@ -11,6 +11,13 @@ class LoginForm(FlaskForm):
     remember_me = BooleanField('Lembrar de mim')
     submit = SubmitField('Entrar')
 
+
+class UserRegistrationForm(FlaskForm):
+    username = StringField('Usuário', validators=[DataRequired()])
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    password = PasswordField('Senha', validators=[DataRequired()])
+    submit = SubmitField('Registrar')
+
 class AppointmentForm(FlaskForm):
     name = StringField('Nome Completo', validators=[DataRequired(), Length(min=3, max=100)])
     email = StringField('Email', validators=[DataRequired(), Email()])

--- a/migrations/versions/add_role_to_user.py
+++ b/migrations/versions/add_role_to_user.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'add_role_to_user'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('user', sa.Column('role', sa.String(length=20), server_default='student', nullable=True))
+    op.execute("UPDATE ""user"" SET role='student' WHERE role IS NULL")
+
+
+def downgrade():
+    op.drop_column('user', 'role')

--- a/models.py
+++ b/models.py
@@ -9,6 +9,7 @@ class User(UserMixin, db.Model):
     username = db.Column(db.String(64), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128))
+    role = db.Column(db.String(20), default='student')
     
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)

--- a/student_routes.py
+++ b/student_routes.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, render_template, redirect, url_for, flash
+from flask_login import login_user, logout_user, login_required, current_user
+from forms import LoginForm, UserRegistrationForm
+from models import User, CourseEnrollment
+from extensions import db
+
+student_bp = Blueprint('student_bp', __name__)
+
+
+@student_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if current_user.is_authenticated:
+        if current_user.role == 'admin':
+            return redirect(url_for('admin_bp.dashboard'))
+        return redirect(url_for('student_bp.dashboard'))
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(username=form.username.data).first()
+        if user is None or not user.check_password(form.password.data):
+            flash('Usuário ou senha inválidos', 'danger')
+            return redirect(url_for('student_bp.login'))
+        login_user(user, remember=form.remember_me.data)
+        if user.role == 'admin':
+            return redirect(url_for('admin_bp.dashboard'))
+        return redirect(url_for('student_bp.dashboard'))
+    return render_template('student/login.html', form=form)
+
+
+@student_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if current_user.is_authenticated:
+        return redirect(url_for('student_bp.dashboard'))
+    form = UserRegistrationForm()
+    if form.validate_on_submit():
+        user = User(username=form.username.data, email=form.email.data, role='student')
+        user.set_password(form.password.data)
+        db.session.add(user)
+        db.session.commit()
+        flash('Registro realizado com sucesso! Faça login.', 'success')
+        return redirect(url_for('student_bp.login'))
+    return render_template('student/register.html', form=form)
+
+
+@student_bp.route('/')
+@login_required
+def dashboard():
+    if current_user.role != 'student':
+        return redirect(url_for('admin_bp.dashboard'))
+    enrollments = CourseEnrollment.query.filter_by(email=current_user.email).all()
+    return render_template('student/dashboard.html', enrollments=enrollments)
+
+
+@student_bp.route('/logout')
+def logout():
+    logout_user()
+    return redirect(url_for('main_bp.index'))

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -94,7 +94,7 @@
                 <p class="mb-0">Dr. Julio Vasconcelos</p>
             </div>
 
-            <div class="login-body">
+              <div class="login-body">
                 {% with messages = get_flashed_messages(with_categories=true) %}
                     {% if messages %}
                         {% for category, message in messages %}
@@ -139,10 +139,13 @@
                     <div class="d-grid">
                         {{ form.submit(class="btn btn-primary btn-login") }}
                     </div>
-                </form>
-            </div>
-        </div>
-    </div>
+                  </form>
+                  <p class="mt-3 text-center">
+                      <a href="{{ url_for('student_bp.login') }}">Área do Aluno</a>
+                  </p>
+              </div>
+          </div>
+      </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>

--- a/templates/student/dashboard.html
+++ b/templates/student/dashboard.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Área do Aluno{% endblock %}
+{% block content %}
+<div class="container mt-5">
+  <h2>Meus Cursos</h2>
+  {% if enrollments %}
+    <ul class="list-group">
+    {% for e in enrollments %}
+      <li class="list-group-item">{{ e.course.title }}</li>
+    {% endfor %}
+    </ul>
+  {% else %}
+    <p>Nenhum curso encontrado.</p>
+  {% endif %}
+  <p class="mt-3"><a href="{{ url_for('student_bp.logout') }}">Sair</a></p>
+</div>
+{% endblock %}

--- a/templates/student/login.html
+++ b/templates/student/login.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}Login Aluno{% endblock %}
+{% block content %}
+<div class="container mt-5">
+  <h2>Login do Aluno</h2>
+  <form method="POST">
+    {{ form.csrf_token }}
+    <div class="mb-3">
+      {{ form.username.label(class="form-label") }}
+      {{ form.username(class="form-control") }}
+    </div>
+    <div class="mb-3">
+      {{ form.password.label(class="form-label") }}
+      {{ form.password(class="form-control") }}
+    </div>
+    <div class="form-check mb-3">
+      {{ form.remember_me(class="form-check-input") }}
+      {{ form.remember_me.label(class="form-check-label") }}
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+  </form>
+  <p class="mt-3">
+    <a href="{{ url_for('student_bp.register') }}">Registrar</a> |
+    <a href="{{ url_for('admin_bp.login') }}">Área Administrativa</a>
+  </p>
+</div>
+{% endblock %}

--- a/templates/student/register.html
+++ b/templates/student/register.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Registrar{% endblock %}
+{% block content %}
+<div class="container mt-5">
+  <h2>Registrar Aluno</h2>
+  <form method="POST">
+    {{ form.csrf_token }}
+    <div class="mb-3">
+      {{ form.username.label(class="form-label") }}
+      {{ form.username(class="form-control") }}
+    </div>
+    <div class="mb-3">
+      {{ form.email.label(class="form-label") }}
+      {{ form.email(class="form-control") }}
+    </div>
+    <div class="mb-3">
+      {{ form.password.label(class="form-label") }}
+      {{ form.password(class="form-control") }}
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+  </form>
+  <p class="mt-3"><a href="{{ url_for('student_bp.login') }}">Já tem uma conta? Entre</a></p>
+</div>
+{% endblock %}

--- a/tests/test_admin_course_crud.py
+++ b/tests/test_admin_course_crud.py
@@ -3,7 +3,7 @@ from models import db, User, Course
 
 
 def create_admin_user():
-    admin = User(username='admin', email='admin@example.com')
+    admin = User(username='admin', email='admin@example.com', role='admin')
     admin.set_password('admin123')
     db.session.add(admin)
     db.session.commit()
@@ -72,3 +72,4 @@ def test_admin_delete_course(client):
     assert resp.status_code == 200
     with client.application.app_context():
         assert Course.query.get(cid) is None
+


### PR DESCRIPTION
## Summary
- add `role` field to users and migration
- create student blueprint with login, registration and course dashboard
- enforce admin-only access with `admin_required` and route redirection
- separate admin and student templates and links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47c2b10e88324a896735d61c937b0