### PR TITLE
Add context processor to student routes

### DIFF
--- a/student_routes.py
+++ b/student_routes.py
@@ -1,10 +1,17 @@
 from flask import Blueprint, render_template, redirect, url_for, flash
 from flask_login import login_user, logout_user, login_required, current_user
 from forms import LoginForm, UserRegistrationForm
-from models import User, CourseEnrollment
+from models import User, CourseEnrollment, Settings
 from extensions import db
+from datetime import datetime
 
 student_bp = Blueprint('student_bp', __name__)
+
+
+@student_bp.context_processor
+def inject_settings():
+    settings = Settings.query.first()
+    return dict(settings=settings or {}, current_year=datetime.now().year)
 
 
 @student_bp.route('/login', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- Expose settings and current year to student templates via context processor

## Testing
- `pytest -q`
- `curl -I http://127.0.0.1:5000/aluno/login`

------
https://chatgpt.com/codex/tasks/task_e_68b48d233e3c8324b065a85a3c14d4e6