### PR TITLE
Set default admin password when updating existing user

### DIFF
--- a/create_admin.py
+++ b/create_admin.py
@@ -1,4 +1,3 @@
-import os
 from app import app
 from models import db, User
 
@@ -13,6 +12,6 @@ with app.app_context():
         print("✅ Usuário admin criado com sucesso.")
     else:
         admin.role = 'admin'
-        admin.set_password(os.environ.get("ADMIN_PASSWORD", "12345678"))
+        admin.set_password("12345678")
         db.session.commit()
         print("🔄 Usuário admin atualizado.")


### PR DESCRIPTION
## Summary
- Update `create_admin.py` to always set default password and role when admin exists

## Testing
- `python create_admin.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b490caa7dc83249e3fbad9981cffea