### PR TITLE
Redirect payment to student dashboard

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -233,6 +233,7 @@ def course_detail(id):
 
 
 @main_bp.route('/pagamento/<int:enrollment_id>', methods=['GET', 'POST'])
+@login_required
 def pay_course(enrollment_id):
     enrollment = CourseEnrollment.query.get_or_404(enrollment_id)
     form = ConfirmPaymentForm()
@@ -248,8 +249,8 @@ def pay_course(enrollment_id):
             )
             db.session.add(transaction)
             db.session.commit()
-            flash('Pagamento realizado com sucesso!', 'success')
-            return redirect(url_for('main_bp.course_access', enrollment_id=enrollment.id))
+            flash('Pagamento realizado', 'success')
+            return redirect(url_for('student_bp.dashboard'))
         except Exception as e:
             db.session.rollback()
             flash(f'Ocorreu um erro no pagamento: {e}', 'danger')


### PR DESCRIPTION
## Summary
- Require login on pay_course and redirect students to dashboard after payment
- Flash "Pagamento realizado" so the dashboard shows the confirmation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4958a0074832492ee92a6dbe988a9