### PR TITLE
Gerar senha temporária no webhook Hotmart

### DIFF
--- a/tests/test_hotmart_webhook.py
+++ b/tests/test_hotmart_webhook.py
@@ -1,6 +1,7 @@
 import json
 import hmac
 import hashlib
+from unittest.mock import patch
 
 from models import Course, User, CourseEnrollment, PaymentTransaction
 from extensions import db
@@ -17,6 +18,7 @@ def test_hotmart_webhook_creates_enrollment(client):
     with client.application.app_context():
         course = create_course(title='Webhook Course', description='desc', price=100, is_active=True)
         course_id = course.id
+        login_path = '/aluno/login'
 
     secret = 'whsec'
     client.application.config['HOTMART_WEBHOOK_SECRET'] = secret
@@ -31,15 +33,32 @@ def test_hotmart_webhook_creates_enrollment(client):
     body = json.dumps(payload).encode()
     signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
-    resp = client.post('/webhook/hotmart', data=body, headers={
-        'Content-Type': 'application/json',
-        'X-HOTMART-HMAC-SHA256': signature,
-    })
+    sent_messages = []
+
+    with client.application.app_context():
+        mail_ext = client.application.extensions['mail']
+
+    def fake_send(message):
+        sent_messages.append(message)
+
+    with patch('routes.secrets.token_urlsafe', return_value='temp-pass'):
+        with patch.object(mail_ext, 'send', side_effect=fake_send):
+            resp = client.post('/webhook/hotmart', data=body, headers={
+                'Content-Type': 'application/json',
+                'X-HOTMART-HMAC-SHA256': signature,
+            })
+
     assert resp.status_code == 200
+    assert len(sent_messages) == 1
+    msg_body = sent_messages[0].body
+    assert login_path in msg_body
+    assert 'temp-pass' in msg_body
+    assert 'Altere sua senha' in msg_body
 
     with client.application.app_context():
         user = User.query.filter_by(email='hook@example.com').first()
         assert user is not None
+        assert user.check_password('temp-pass')
         enrollment = CourseEnrollment.query.filter_by(course_id=course_id, email='hook@example.com').first()
         assert enrollment is not None
         assert enrollment.payment_status == 'approved'


### PR DESCRIPTION
## Summary
- Generate and store a temporary password when creating a user via Hotmart webhook
- Send login link and temporary password in the enrollment email with a reminder to change it
- Cover webhook email flow with a test that captures the sent message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4963847508324a0c745d83db493f5