### PR TITLE
Add user_id to CourseEnrollment

### DIFF
--- a/migrations/versions/f4797847a3d9_add_user_id_to_courseenrollment.py
+++ b/migrations/versions/f4797847a3d9_add_user_id_to_courseenrollment.py
@@ -1,0 +1,21 @@
+"""Add user_id to CourseEnrollment"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f4797847a3d9'
+down_revision = 'add_role_to_user'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('course_enrollment') as batch_op:
+        batch_op.add_column(sa.Column('user_id', sa.Integer(), nullable=True))
+        batch_op.create_foreign_key('fk_course_enrollment_user', 'user', ['user_id'], ['id'])
+
+
+def downgrade():
+    with op.batch_alter_table('course_enrollment') as batch_op:
+        batch_op.drop_constraint('fk_course_enrollment_user', type_='foreignkey')
+        batch_op.drop_column('user_id')

--- a/scripts/backfill_user_ids.py
+++ b/scripts/backfill_user_ids.py
@@ -1,0 +1,25 @@
+"""Backfill user_id for course enrollments based on matching email addresses."""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import app
+from extensions import db
+from models import CourseEnrollment, User
+
+
+def backfill_user_ids():
+    with app.app_context():
+        enrollments = CourseEnrollment.query.filter_by(user_id=None).all()
+        for enrollment in enrollments:
+            user = User.query.filter_by(email=enrollment.email).first()
+            if user:
+                enrollment.user_id = user.id
+        if enrollments:
+            db.session.commit()
+
+
+if __name__ == "__main__":
+    backfill_user_ids()


### PR DESCRIPTION
## Summary
- add Alembic migration for course_enrollment.user_id
- provide script to backfill course enrollment `user_id` from email

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b49b68a4e88324b591ba98639cd472