### PR TITLE
Prefill course registration using current user

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -157,14 +157,21 @@ def register_course(id):
     settings = Settings.query.first()
     form = CourseRegistrationForm()
 
+    if current_user.is_authenticated:
+        form.participant_name.data = current_user.username
+        form.participant_email.data = current_user.email
+
     def _finalize_enrollment(registration, transaction_id=None):
-        user = User.query.filter_by(email=registration.participant_email).first()
-        if not user:
-            username = registration.participant_email.split('@')[0]
-            user = User(username=username, email=registration.participant_email, role='student')
-            user.set_password(secrets.token_urlsafe(8))
-            db.session.add(user)
-            db.session.flush()
+        if current_user.is_authenticated:
+            user = current_user
+        else:
+            user = User.query.filter_by(email=registration.participant_email).first()
+            if not user:
+                username = registration.participant_email.split('@')[0]
+                user = User(username=username, email=registration.participant_email, role='student')
+                user.set_password(secrets.token_urlsafe(8))
+                db.session.add(user)
+                db.session.flush()
 
         enrollment = CourseEnrollment.query.filter_by(course_id=course.id, user_id=user.id).first()
         if not enrollment:

--- a/templates/course_register.html
+++ b/templates/course_register.html
@@ -14,20 +14,25 @@
         <div class="col-md-6">
             <form method="POST">
                 {{ form.csrf_token }}
-                <div class="mb-3">
-                    {{ form.participant_name.label(class='form-label text-light') }}
-                    {{ form.participant_name(class='form-control bg-darker text-white') }}
-                    {% for error in form.participant_name.errors %}
-                    <div class="invalid-feedback d-block">{{ error }}</div>
-                    {% endfor %}
-                </div>
-                <div class="mb-3">
-                    {{ form.participant_email.label(class='form-label text-light') }}
-                    {{ form.participant_email(class='form-control bg-darker text-white') }}
-                    {% for error in form.participant_email.errors %}
-                    <div class="invalid-feedback d-block">{{ error }}</div>
-                    {% endfor %}
-                </div>
+                {% if current_user.is_authenticated %}
+                    {{ form.participant_name(type='hidden') }}
+                    {{ form.participant_email(type='hidden') }}
+                {% else %}
+                    <div class="mb-3">
+                        {{ form.participant_name.label(class='form-label text-light') }}
+                        {{ form.participant_name(class='form-control bg-darker text-white') }}
+                        {% for error in form.participant_name.errors %}
+                        <div class="invalid-feedback d-block">{{ error }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.participant_email.label(class='form-label text-light') }}
+                        {{ form.participant_email(class='form-control bg-darker text-white') }}
+                        {% for error in form.participant_email.errors %}
+                        <div class="invalid-feedback d-block">{{ error }}</div>
+                        {% endfor %}
+                    </div>
+                {% endif %}
                 <div class="d-grid">
                     {{ form.submit(class='btn btn-primary') }}
                 </div>


### PR DESCRIPTION
## Summary
- Prefill CourseRegistrationForm with logged-in user's data and rely on current_user during enrollment
- Hide name and email inputs on the course registration page when the user is authenticated

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a653188c8324991503a24628b9e0