### PR TITLE
Link student dashboard courses to course access

### DIFF
--- a/templates/student/dashboard.html
+++ b/templates/student/dashboard.html
@@ -6,7 +6,9 @@
   {% if enrollments %}
     <ul class="list-group">
     {% for e in enrollments %}
-      <li class="list-group-item">{{ e.course.title }}</li>
+      <li class="list-group-item">
+        <a href="{{ url_for('main_bp.course_access', enrollment_id=e.id) }}">{{ e.course.title }}</a>
+      </li>
     {% endfor %}
     </ul>
   {% else %}


### PR DESCRIPTION
## Summary
- Turn student dashboard course list items into links to their course access pages

## Testing
- `pytest`
- Manual test: created student with paid enrollment, login, verified dashboard link and course access page loads

------
https://chatgpt.com/codex/tasks/task_e_68b4a926bee88324af22480c394180ff