### PR TITLE
Map Hotmart webhook statuses to internal payment values

### DIFF
--- a/tests/test_hotmart_webhook.py
+++ b/tests/test_hotmart_webhook.py
@@ -3,6 +3,8 @@ import hmac
 import hashlib
 from unittest.mock import patch
 
+import pytest
+
 from models import Course, User, CourseEnrollment, PaymentTransaction
 from extensions import db
 
@@ -14,7 +16,15 @@ def create_course(**kwargs):
     return course
 
 
-def test_hotmart_webhook_creates_enrollment(client):
+@pytest.mark.parametrize(
+    'webhook_status,expected_status',
+    [
+        ('approved', 'paid'),
+        ('refunded', 'refunded'),
+        ('canceled', 'canceled'),
+    ],
+)
+def test_hotmart_webhook_creates_enrollment(client, webhook_status, expected_status):
     with client.application.app_context():
         course = create_course(title='Webhook Course', description='desc', price=100, is_active=True)
         course_id = course.id
@@ -22,13 +32,14 @@ def test_hotmart_webhook_creates_enrollment(client):
 
     secret = 'whsec'
     client.application.config['HOTMART_WEBHOOK_SECRET'] = secret
+    email = f'hook-{webhook_status}@example.com'
     payload = {
-        'status': 'approved',
+        'status': webhook_status,
         'id': course_id,
-        'email': 'hook@example.com',
+        'email': email,
         'name': 'Hook User',
         'amount': 100,
-        'transaction_id': 'tx123'
+        'transaction_id': 'tx123',
     }
     body = json.dumps(payload).encode()
     signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
@@ -43,10 +54,14 @@ def test_hotmart_webhook_creates_enrollment(client):
 
     with patch('routes.secrets.token_urlsafe', return_value='temp-pass'):
         with patch.object(mail_ext, 'send', side_effect=fake_send):
-            resp = client.post('/webhook/hotmart', data=body, headers={
-                'Content-Type': 'application/json',
-                'X-HOTMART-HMAC-SHA256': signature,
-            })
+            resp = client.post(
+                '/webhook/hotmart',
+                data=body,
+                headers={
+                    'Content-Type': 'application/json',
+                    'X-HOTMART-HMAC-SHA256': signature,
+                },
+            )
 
     assert resp.status_code == 200
     assert len(sent_messages) == 1
@@ -56,13 +71,14 @@ def test_hotmart_webhook_creates_enrollment(client):
     assert 'Altere sua senha' in msg_body
 
     with client.application.app_context():
-        user = User.query.filter_by(email='hook@example.com').first()
+        user = User.query.filter_by(email=email).first()
         assert user is not None
         assert user.check_password('temp-pass')
-        enrollment = CourseEnrollment.query.filter_by(course_id=course_id, email='hook@example.com').first()
+        enrollment = CourseEnrollment.query.filter_by(course_id=course_id, email=email).first()
         assert enrollment is not None
-        assert enrollment.payment_status == 'approved'
+        assert enrollment.payment_status == expected_status
         txn = PaymentTransaction.query.filter_by(enrollment_id=enrollment.id).first()
         assert txn is not None
         assert txn.amount == 100
         assert txn.provider_id == 'tx123'
+        assert txn.status == expected_status


### PR DESCRIPTION
## Summary
- map Hotmart webhook statuses to internal status values
- record mapped status on enrollments and transactions
- test webhook mapping for approved, refunded, and canceled statuses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4aff47b488324b1bd8374fb72e798