### PR TITLE
Handle Hotmart webhook with HMAC validation

### DIFF
--- a/models.py
+++ b/models.py
@@ -175,6 +175,7 @@ class CourseEnrollment(db.Model):
     email = db.Column(db.String(100), nullable=False)
     phone = db.Column(db.String(20))
     payment_status = db.Column(db.String(20), default='pending')
+    transaction_id = db.Column(db.String(100))
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     access_start = db.Column(db.DateTime)
     access_end = db.Column(db.DateTime)

--- a/tests/test_course_access_after_webhook.py
+++ b/tests/test_course_access_after_webhook.py
@@ -25,11 +25,10 @@ def test_webhook_payment_allows_course_access(client):
     secret = 'whsec'
     client.application.config['HOTMART_WEBHOOK_SECRET'] = secret
     payload = {
-        'status': 'paid',
+        'status': 'approved',
         'id': course_id,
         'email': 'student@example.com',
         'name': 'Student',
-        'amount': 50,
         'transaction_id': 'tx999'
     }
     body = json.dumps(payload).encode()
@@ -48,6 +47,7 @@ def test_webhook_payment_allows_course_access(client):
         enrollment = CourseEnrollment.query.filter_by(course_id=course_id, user_id=user_id).first()
         assert enrollment is not None
         assert enrollment.access_end is not None
+        assert enrollment.transaction_id == 'tx999'
         enrollment_id = enrollment.id
 
     resp_no_login = client.get(f'/curso/acesso/{enrollment_id}')


### PR DESCRIPTION
## Summary
- add transaction_id field to `CourseEnrollment`
- implement `/webhook/hotmart` route with HMAC validation, logging and email notifications
- test Hotmart webhook handling including invalid signatures and course access

## Testing
- `pytest tests/test_hotmart_webhook.py tests/test_course_access_after_webhook.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b7134ae083248f911653db691a26