### PR TITLE
Add Hotmart client credentials configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Flask settings
+SECRET_KEY=change-me
+DATABASE_URL=sqlite:///dr_julio.db
+
+# Email settings
+MAIL_SERVER=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USE_TLS=true
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_DEFAULT_SENDER="Dr. Julio Vasconcelos <noreply@drjulio.com>"
+
+# Stripe settings
+STRIPE_SECRET_KEY=
+STRIPE_PUBLIC_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Hotmart settings
+HOTMART_WEBHOOK_SECRET=
+HOTMART_CLIENT_ID=
+HOTMART_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Flask e pelo envio de emails. As principais variáveis são:
 - `MAIL_SERVER`, `MAIL_PORT`, `MAIL_USE_TLS`, `MAIL_USERNAME`, `MAIL_PASSWORD`,
   `MAIL_DEFAULT_SENDER` – dados para o servidor de email.
 
-Não existem variáveis específicas para cursos ou pagamentos até o momento.
+- `HOTMART_WEBHOOK_SECRET` – segredo para validar notificações do Hotmart.
+- `HOTMART_CLIENT_ID` e `HOTMART_CLIENT_SECRET` – credenciais OAuth da API do Hotmart.
+
+As credenciais do Hotmart podem ser geradas no [Painel de Desenvolvedor do Hotmart](https://developers.hotmart.com/).
+Crie uma nova aplicação para obter o Client ID e o Client Secret e então defina-os no arquivo `.env`.
 
 ## Cursos
 

--- a/config.py
+++ b/config.py
@@ -30,8 +30,10 @@ class Config:
     STRIPE_PUBLIC_KEY = os.environ.get('STRIPE_PUBLIC_KEY', '')
     STRIPE_WEBHOOK_SECRET = os.environ.get('STRIPE_WEBHOOK_SECRET', '')
 
-    # Hotmart webhook secret for validating callbacks
+    # Hotmart configuration
     HOTMART_WEBHOOK_SECRET = os.environ.get('HOTMART_WEBHOOK_SECRET', '')
+    HOTMART_CLIENT_ID = os.environ.get('HOTMART_CLIENT_ID', '')
+    HOTMART_CLIENT_SECRET = os.environ.get('HOTMART_CLIENT_SECRET', '')
 
     # Default number of days a student can access a course after payment
     COURSE_ACCESS_DAYS = int(os.environ.get('COURSE_ACCESS_DAYS', 365))


### PR DESCRIPTION
## Summary
- Load Hotmart client ID and secret from environment variables
- Provide sample variables for Hotmart integration in `.env.example`
- Document how to generate Hotmart credentials in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4bd398f60832491cb9e5b0747f186