### PR TITLE
Add Hotmart token retrieval with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Flask e pelo envio de emails. As principais variáveis são:
 
 - `HOTMART_WEBHOOK_SECRET` – segredo para validar notificações do Hotmart.
 - `HOTMART_CLIENT_ID` e `HOTMART_CLIENT_SECRET` – credenciais OAuth da API do Hotmart.
+- `HOTMART_USE_SANDBOX` – define se a API do Hotmart deve utilizar o ambiente de testes.
 
 As credenciais do Hotmart podem ser geradas no [Painel de Desenvolvedor do Hotmart](https://developers.hotmart.com/).
 Crie uma nova aplicação para obter o Client ID e o Client Secret e então defina-os no arquivo `.env`.

--- a/config.py
+++ b/config.py
@@ -34,6 +34,7 @@ class Config:
     HOTMART_WEBHOOK_SECRET = os.environ.get('HOTMART_WEBHOOK_SECRET', '')
     HOTMART_CLIENT_ID = os.environ.get('HOTMART_CLIENT_ID', '')
     HOTMART_CLIENT_SECRET = os.environ.get('HOTMART_CLIENT_SECRET', '')
+    HOTMART_USE_SANDBOX = os.environ.get('HOTMART_USE_SANDBOX', 'false').lower() in ['true', 'on', '1']
 
     # Default number of days a student can access a course after payment
     COURSE_ACCESS_DAYS = int(os.environ.get('COURSE_ACCESS_DAYS', 365))

--- a/hotmart.py
+++ b/hotmart.py
@@ -1,0 +1,69 @@
+"""Helpers for interacting with the Hotmart API."""
+
+from __future__ import annotations
+
+import base64
+import time
+from typing import Any, Dict
+
+import requests
+from flask import current_app
+
+# Simple in-memory cache for the access token
+_token_cache: Dict[str, Any] | None = None
+
+
+def _token_expired() -> bool:
+    """Return True if the cached token is missing or expired."""
+    global _token_cache
+    if not _token_cache:
+        return True
+    return _token_cache.get("expires_at", 0) <= time.time()
+
+
+def get_hotmart_token() -> str:
+    """Retrieve a Hotmart access token using the client credentials flow.
+
+    The token is cached in memory until shortly before its expiration.
+    If a valid token is present, it is returned without making a new
+    request. When expired, a new token is automatically requested.
+    """
+
+    global _token_cache
+
+    if not _token_expired():
+        return _token_cache["access_token"]
+
+    client_id = current_app.config.get("HOTMART_CLIENT_ID", "")
+    client_secret = current_app.config.get("HOTMART_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError("Hotmart credentials not configured")
+
+    auth_bytes = f"{client_id}:{client_secret}".encode()
+    auth_header = base64.b64encode(auth_bytes).decode()
+
+    use_sandbox = current_app.config.get("HOTMART_USE_SANDBOX", False)
+    base_url = "https://sandbox.hotmart.com" if use_sandbox else "https://api.hotmart.com"
+    url = f"{base_url}/oauth/token"
+
+    headers = {"Authorization": f"Basic {auth_header}"}
+    data = {"grant_type": "client_credentials"}
+
+    resp = requests.post(url, headers=headers, data=data, timeout=10)
+    resp.raise_for_status()
+    payload = resp.json()
+
+    access_token = payload.get("access_token")
+    expires_in = int(payload.get("expires_in", 0))
+
+    _token_cache = {
+        "access_token": access_token,
+        # Renew one minute before actual expiration
+        "expires_at": time.time() + max(expires_in - 60, 0),
+    }
+
+    return access_token
+
+
+__all__ = ["get_hotmart_token"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ Flask-Login==0.6.2
 gunicorn==21.2.0
 Flask-Migrate==4.0.4
 stripe
+requests

--- a/tests/test_hotmart_token.py
+++ b/tests/test_hotmart_token.py
@@ -1,0 +1,72 @@
+import time
+
+import hotmart
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_token_is_cached(client, monkeypatch):
+    hotmart._token_cache = None
+    app = client.application
+    calls = []
+
+    def fake_post(url, headers=None, data=None, timeout=None):
+        calls.append(url)
+        return DummyResponse({"access_token": "tok1", "expires_in": 3600})
+
+    monkeypatch.setattr(hotmart.requests, "post", fake_post)
+
+    with app.app_context():
+        app.config["HOTMART_CLIENT_ID"] = "id"
+        app.config["HOTMART_CLIENT_SECRET"] = "secret"
+        tok_a = hotmart.get_hotmart_token()
+        tok_b = hotmart.get_hotmart_token()
+
+    assert tok_a == "tok1"
+    assert tok_b == "tok1"
+    assert len(calls) == 1
+
+
+def test_token_refreshes_when_expired(client, monkeypatch):
+    hotmart._token_cache = None
+    app = client.application
+    first_calls = []
+
+    def first_post(url, headers=None, data=None, timeout=None):
+        first_calls.append(url)
+        return DummyResponse({"access_token": "tok1", "expires_in": 1})
+
+    monkeypatch.setattr(hotmart.requests, "post", first_post)
+
+    with app.app_context():
+        app.config["HOTMART_CLIENT_ID"] = "id"
+        app.config["HOTMART_CLIENT_SECRET"] = "secret"
+        tok1 = hotmart.get_hotmart_token()
+
+    # Expire the token
+    hotmart._token_cache["expires_at"] = time.time() - 1
+
+    second_calls = []
+
+    def second_post(url, headers=None, data=None, timeout=None):
+        second_calls.append(url)
+        return DummyResponse({"access_token": "tok2", "expires_in": 3600})
+
+    monkeypatch.setattr(hotmart.requests, "post", second_post)
+
+    with app.app_context():
+        tok2 = hotmart.get_hotmart_token()
+
+    assert tok1 == "tok1"
+    assert tok2 == "tok2"
+    assert len(first_calls) == 1
+    assert len(second_calls) == 1


### PR DESCRIPTION
## Summary
- add sandbox toggle for Hotmart API
- implement Hotmart OAuth client credentials flow with in-memory cache
- test token caching and automatic renewal

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4be05514c8324968c5ec083f4e3d1