### PR TITLE
Add Hotmart subscriptions API helper

### DIFF
--- a/hotmart_api.py
+++ b/hotmart_api.py
@@ -1,0 +1,56 @@
+"""High level functions for Hotmart API interactions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import requests
+from flask import current_app
+
+from hotmart import get_hotmart_token
+
+
+def _base_url() -> str:
+    """Return the base URL for the Hotmart API."""
+    use_sandbox = current_app.config.get("HOTMART_USE_SANDBOX", False)
+    return "https://sandbox.hotmart.com" if use_sandbox else "https://api.hotmart.com"
+
+
+def list_subscriptions(offset: int = 0, limit: int = 20) -> Dict[str, Any]:
+    """List subscriptions from the Hotmart API.
+
+    Parameters
+    ----------
+    offset: int
+        The result offset for pagination.
+    limit: int
+        The maximum number of items to return.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The JSON response from the Hotmart API.
+    """
+    token = get_hotmart_token()
+    url = f"{_base_url()}/payments/v1/subscriptions"
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"offset": offset, "limit": limit}
+
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=10)
+    except requests.RequestException:
+        current_app.logger.exception("Failed to request Hotmart subscriptions")
+        raise
+
+    if resp.status_code == 401:
+        current_app.logger.error("Hotmart API unauthorized when listing subscriptions")
+    elif resp.status_code == 404:
+        current_app.logger.error("Hotmart subscriptions endpoint not found")
+    elif resp.status_code == 500:
+        current_app.logger.error("Hotmart API internal server error listing subscriptions")
+
+    resp.raise_for_status()
+    return resp.json()
+
+
+__all__ = ["list_subscriptions"]

--- a/tests/test_hotmart_api.py
+++ b/tests/test_hotmart_api.py
@@ -1,0 +1,53 @@
+import logging
+import pytest
+import requests
+
+import hotmart_api
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, data=None):
+        self.status_code = status_code
+        self._data = data or {}
+        self.text = ""
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+
+def test_list_subscriptions_success(client, monkeypatch):
+    called = {}
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        called["url"] = url
+        called["headers"] = headers
+        called["params"] = params
+        return DummyResponse(200, {"items": []})
+
+    monkeypatch.setattr(hotmart_api, "get_hotmart_token", lambda: "tok")
+    monkeypatch.setattr(hotmart_api.requests, "get", fake_get)
+
+    with client.application.app_context():
+        data = hotmart_api.list_subscriptions(offset=5, limit=10)
+
+    assert called["headers"]["Authorization"] == "Bearer tok"
+    assert called["params"] == {"offset": 5, "limit": 10}
+    assert data == {"items": []}
+
+
+@pytest.mark.parametrize("status", [401, 404, 500])
+def test_list_subscriptions_logs_errors(client, monkeypatch, caplog, status):
+    def fake_get(url, headers=None, params=None, timeout=None):
+        return DummyResponse(status)
+
+    monkeypatch.setattr(hotmart_api, "get_hotmart_token", lambda: "tok")
+    monkeypatch.setattr(hotmart_api.requests, "get", fake_get)
+
+    with client.application.app_context(), caplog.at_level(logging.ERROR), pytest.raises(requests.HTTPError):
+        hotmart_api.list_subscriptions()
+
+    assert any(record.levelno == logging.ERROR for record in caplog.records)


### PR DESCRIPTION
## Summary
- add `list_subscriptions` helper using Hotmart token and logs for 401/404/500
- cover Hotmart API helper with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4bf4bcf648324a3f5b67053bf9b25