### PR TITLE
Add transaction_id field to course enrollment

### DIFF
--- a/migrations/versions/2491c86f1287_add_transaction_id_to_courseenrollment.py
+++ b/migrations/versions/2491c86f1287_add_transaction_id_to_courseenrollment.py
@@ -1,0 +1,17 @@
+"""Add transaction_id to CourseEnrollment"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '2491c86f1287'
+down_revision = 'b6f3d6e3a6aa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('course_enrollment', sa.Column('transaction_id', sa.String(length=100), nullable=True))
+
+
+def downgrade():
+    op.drop_column('course_enrollment', 'transaction_id')


### PR DESCRIPTION
## Summary
- add Alembic migration to introduce `transaction_id` column on `course_enrollment`

## Testing
- `flask db migrate -m "Add transaction_id to CourseEnrollment"`
- `flask db upgrade`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4c1f93dac8324aa119404cce7dad1