### PR TITLE
Handle duplicate admin user creation in tests

### DIFF
--- a/tests/test_admin_course_crud.py
+++ b/tests/test_admin_course_crud.py
@@ -3,14 +3,20 @@ from models import db, User, Course
 
 
 def create_admin_user():
-    admin = User(username='admin', email='admin@example.com', role='admin')
-    admin.set_password('admin123')
-    db.session.add(admin)
-    db.session.commit()
+    """Return existing admin user or create a new one."""
+    admin = User.query.filter_by(email='admin@example.com').first()
+    if admin is None:
+        admin = User(username='admin', email='admin@example.com', role='admin')
+        admin.set_password('admin123')
+        db.session.add(admin)
+        db.session.commit()
     return admin
 
 
 def login(client, username='admin', password='admin123'):
+    # Ensure the admin user exists before attempting login
+    with client.application.app_context():
+        create_admin_user()
     return client.post(
         '/admin/login',
         data={'username': username, 'password': password},


### PR DESCRIPTION
## Summary
- Use get-or-create in `create_admin_user` to avoid duplicate admin insertions
- Ensure `login` creates the admin user if needed
- Update course CRUD tests to rely on idempotent helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c68e8d1083248c18c56eacd21333