### PR TITLE
Restrict payment to enrollment owner

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -280,6 +280,8 @@ def register_course(id):
 @login_required
 def pay_course(enrollment_id):
     enrollment = CourseEnrollment.query.get_or_404(enrollment_id)
+    if enrollment.user_id != current_user.id:
+        abort(403)
     form = ConfirmPaymentForm()
     if enrollment.payment_status == 'paid':
         return redirect(url_for('main_bp.course_access', enrollment_id=enrollment.id))

--- a/tests/test_pay_course_authorization.py
+++ b/tests/test_pay_course_authorization.py
@@ -1,0 +1,25 @@
+from models import Course, User, CourseEnrollment
+from extensions import db
+
+
+def test_pay_course_rejects_other_users(client):
+    with client.application.app_context():
+        course = Course(title='Secure', description='desc', price=100)
+        owner = User(username='owner', email='owner@example.com', role='student')
+        owner.set_password('pass1')
+        intruder = User(username='intruder', email='intruder@example.com', role='student')
+        intruder.set_password('pass2')
+        enrollment = CourseEnrollment(
+            course=course,
+            user=owner,
+            name='Owner',
+            email=owner.email,
+            payment_status='pending',
+        )
+        db.session.add_all([course, owner, intruder, enrollment])
+        db.session.commit()
+        enrollment_id = enrollment.id
+
+    client.post('/aluno/login', data={'username': 'intruder', 'password': 'pass2'})
+    resp = client.get(f'/pagamento/{enrollment_id}')
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- Ensure pay_course route denies access when a user attempts to pay another user's enrollment
- Test that unauthorized users receive 403 when accessing enrollment payment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4c7a5f6008324ae9facc66d213791