### PR TITLE
Record Hotmart webhook transactions

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -576,6 +576,7 @@ def hotmart_webhook():
             transaction_id=txn_id,
         )
         db.session.add(enrollment)
+        db.session.flush()
         current_app.logger.info('Created enrollment %s for user %s', enrollment.id, user.id)
     else:
         enrollment.payment_status = 'paid'
@@ -583,6 +584,15 @@ def hotmart_webhook():
         current_app.logger.info('Updated enrollment %s for user %s', enrollment.id, user.id)
     if not enrollment.access_start:
         enrollment.activate_access()
+
+    amount = payload.get('price') or payload.get('amount') or course.price
+    transaction = PaymentTransaction(
+        enrollment_id=enrollment.id,
+        amount=amount,
+        provider_id=txn_id,
+        status='paid'
+    )
+    db.session.add(transaction)
 
     db.session.commit()
 

--- a/tests/test_course_access_after_webhook.py
+++ b/tests/test_course_access_after_webhook.py
@@ -2,7 +2,7 @@ import json
 import hmac
 import hashlib
 
-from models import Course, User, CourseEnrollment
+from models import Course, User, CourseEnrollment, PaymentTransaction
 from extensions import db
 
 
@@ -48,6 +48,10 @@ def test_webhook_payment_allows_course_access(client):
         assert enrollment is not None
         assert enrollment.access_end is not None
         assert enrollment.transaction_id == 'tx999'
+        txn = PaymentTransaction.query.filter_by(enrollment_id=enrollment.id, provider_id='tx999').first()
+        assert txn is not None
+        course = Course.query.get(course_id)
+        assert txn.amount == course.price
         enrollment_id = enrollment.id
 
     resp_no_login = client.get(f'/curso/acesso/{enrollment_id}')

--- a/tests/test_hotmart_webhook.py
+++ b/tests/test_hotmart_webhook.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from models import Course, User, CourseEnrollment
+from models import Course, User, CourseEnrollment, PaymentTransaction
 from extensions import db
 
 
@@ -72,6 +72,10 @@ def test_hotmart_webhook_creates_enrollment(client, caplog):
         assert enrollment is not None
         assert enrollment.payment_status == 'paid'
         assert enrollment.transaction_id == 'tx123'
+        txn = PaymentTransaction.query.filter_by(enrollment_id=enrollment.id, provider_id='tx123').first()
+        assert txn is not None
+        course = Course.query.get(course_id)
+        assert txn.amount == course.price
 
 
 def test_hotmart_webhook_invalid_signature(client):


### PR DESCRIPTION
## Summary
- log Hotmart webhook enrollments as PaymentTransaction records
- extend webhook tests to check for stored transactions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ca9e2a1c8324befd2b300afc5730