### PR TITLE
Use migrations and seeding script for admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Aplicação web em Flask para gerenciamento de agendamentos, eventos e conteúdo
    pip install -r requirements.txt
    ```
 
+3. Execute as migrações e crie o usuário administrador:
+   ```bash
+   flask db upgrade
+   python create_admin.py
+   ```
+
 ## Como executar
 
 A aplicação pode ser iniciada diretamente usando `run.py`:
@@ -23,7 +29,6 @@ python run.py
 ```
 
 Isso criará a pasta `static/uploads` caso não exista e rodará o servidor em `http://localhost:5000`.
-Na primeira execução o script também cria automaticamente um usuário administrador e configurações iniciais.
 
 Para produção é possível utilizar o `Procfile` com Gunicorn. O arquivo `runtime.txt` define a versão do Python.
 
@@ -31,7 +36,7 @@ Para produção é possível utilizar o `Procfile` com Gunicorn. O arquivo `runt
 
 
 As migrações do banco ficam na pasta `migrations/`.
-Depois de clonar o projeto execute `flask db upgrade` para criar todas as tabelas.
+Depois de clonar o projeto execute `flask db upgrade` para criar todas as tabelas e em seguida `python create_admin.py` para inserir ou atualizar o usuário administrador.
 Com o ambiente virtual ativo e `FLASK_APP` apontando para `app.py`, gere uma nova migração sempre que modificar os modelos e aplique-a:
 
 ```bash

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import os
 
 from config import Config
 from extensions import db  # Correto: db importado do extensions.py
-from models import User, Event, Appointment, Settings
+from models import User
 from routes import main_bp
 from admin_routes import admin_bp
 from student_routes import student_bp
@@ -32,26 +32,6 @@ app.register_blueprint(student_bp, url_prefix='/aluno')
 def load_user(user_id):
     return User.query.get(int(user_id))
 
-# Inicialização customizada (sem create_all)
-def create_initial_data():
-    with app.app_context():
-        db.create_all()
-        if not User.query.filter_by(username='admin').first():
-            user = User(username='admin', email='admin@example.com', role='admin')
-            user.set_password('admin123')
-            db.session.add(user)
-
-            if not Settings.query.first():
-                settings = Settings(
-                    site_title="Dr. Julio Vasconcelos",
-                    contact_email="contato@drjulio.com",
-                    contact_phone="(11) 99999-9999",
-                    address="Av. Paulista, 1000, São Paulo - SP",
-                    about_text="Médico experiente com anos de prática clínica."
-                )
-                db.session.add(settings)
-
-            db.session.commit()
 
 # Criação de pasta de uploads caso não exista
 if __name__ == '__main__':
@@ -62,6 +42,5 @@ if __name__ == '__main__':
     content_path = os.path.join(app.root_path, 'course_content')
     os.makedirs(content_path, exist_ok=True)
 
-    create_initial_data()  # ✅ Só executa quando rodar diretamente (não em flask db ...)
     app.run(debug=True)
 

--- a/create_admin.py
+++ b/create_admin.py
@@ -2,16 +2,14 @@ from app import app
 from models import db, User
 
 with app.app_context():
-    db.create_all()
     admin = User.query.filter_by(username="admin").first()
     if not admin:
         admin = User(username="admin", email="admin@drjulio.com", role='admin')
         admin.set_password("12345678")
         db.session.add(admin)
-        db.session.commit()
         print("✅ Usuário admin criado com sucesso.")
     else:
         admin.role = 'admin'
         admin.set_password("12345678")
-        db.session.commit()
         print("🔄 Usuário admin atualizado.")
+    db.session.commit()

--- a/run.py
+++ b/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from app import app, create_initial_data
+from app import app
 import os
 
 if __name__ == '__main__':
@@ -14,8 +14,5 @@ if __name__ == '__main__':
     if not os.path.exists(content_dir):
         os.makedirs(content_dir)
         
-    # Initialize default data (admin user and settings)
-    create_initial_data()
-
     # Run the application
     app.run(debug=True, host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- remove `db.create_all()` calls from app and runner
- add seeding script to create/update admin user
- document running migrations then seeding admin user

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4dabcf02883249846a97bb97a9578