### PR TITLE
Provide global settings context and guard template access

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,11 +2,12 @@ from flask import Flask
 from flask_login import LoginManager
 from flask_mail import Mail
 from flask_migrate import Migrate
+from datetime import datetime
 import os
 
 from config import Config
 from extensions import db  # Correto: db importado do extensions.py
-from models import User
+from models import User, Settings
 from routes import main_bp
 from admin_routes import admin_bp
 from student_routes import student_bp
@@ -31,6 +32,12 @@ app.register_blueprint(student_bp, url_prefix='/aluno')
 @login_manager.user_loader
 def load_user(user_id):
     return User.query.get(int(user_id))
+
+
+@app.context_processor
+def inject_settings():
+    settings = Settings.query.first()
+    return dict(settings=settings or {}, current_year=datetime.now().year)
 
 
 # Criação de pasta de uploads caso não exista

--- a/routes.py
+++ b/routes.py
@@ -637,13 +637,6 @@ def course_catalog_detail(course_id):
     settings = Settings.query.first()
     return render_template('course_catalog_detail.html', course=course, settings=settings)
 
-@main_bp.context_processor
-def inject_settings():
-    settings = Settings.query.first()
-    # Add current_year to the context for use in all templates
-    return dict(settings=settings or {}, current_year=datetime.now().year)
-
-
 @main_bp.route('/galeria')
 def gallery():
     from models import GalleryItem  # (após criarmos a model)

--- a/student_routes.py
+++ b/student_routes.py
@@ -1,19 +1,10 @@
 from flask import Blueprint, render_template, redirect, url_for, flash
 from flask_login import login_user, logout_user, login_required, current_user
 from forms import LoginForm, UserRegistrationForm
-from models import User, CourseEnrollment, Settings
+from models import User, CourseEnrollment
 from extensions import db
-from datetime import datetime
 
 student_bp = Blueprint('student_bp', __name__)
-
-
-@student_bp.context_processor
-def inject_settings():
-    settings = Settings.query.first()
-    return dict(settings=settings or {}, current_year=datetime.now().year)
-
-
 @student_bp.route('/login', methods=['GET', 'POST'])
 def login():
     if current_user.is_authenticated:

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ settings.site_title if settings else 'Dr. Julio Vasconcelos' }} | {% block title %}{% endblock %}</title>
+    <title>{{ settings.site_title if settings and settings.site_title else 'Dr. Julio Vasconcelos' }} | {% block title %}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
@@ -18,7 +18,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container">
             <a class="navbar-brand" href="{{ url_for('main_bp.index') }}">
-                {% if settings %}{{ settings.site_title }}{% else %}Dr. Julio Vasconcelos{% endif %}
+                {% if settings and settings.site_title %}{{ settings.site_title }}{% else %}Dr. Julio Vasconcelos{% endif %}
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>
@@ -80,7 +80,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-4">
-                    <h5>Dr. Julio Vasconcelos</h5>
+                    <h5>{{ settings.site_title if settings and settings.site_title else 'Dr. Julio Vasconcelos' }}</h5>
                     {% if settings and settings.about_text %}
                         <p>{{ settings.about_text | truncate(100) }}</p>
                     {% else %}


### PR DESCRIPTION
## Summary
- Inject `settings` and `current_year` globally with an app-wide context processor
- Guard `base.html` template accesses when `settings` fields are missing to prevent errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4dbf3b6048324ad490f8e08e566ff