### PR TITLE
Protect admin routes and update student navigation

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -35,6 +35,7 @@ def admin_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if not current_user.is_authenticated or current_user.role != 'admin':
+            flash('Acesso restrito aos administradores', 'danger')
             return redirect(url_for('admin_bp.login'))
         return f(*args, **kwargs)
     return decorated_function

--- a/models.py
+++ b/models.py
@@ -10,7 +10,7 @@ class User(UserMixin, db.Model):
     username = db.Column(db.String(64), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128))
-    role = db.Column(db.String(20), default='student')
+    role = db.Column(db.String(20), default='student', nullable=False)
     
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)

--- a/student_routes.py
+++ b/student_routes.py
@@ -40,6 +40,7 @@ def register():
 
 
 @student_bp.route('/')
+@student_bp.route('/dashboard')
 @login_required
 def dashboard():
     if current_user.role != 'student':

--- a/templates/base.html
+++ b/templates/base.html
@@ -46,10 +46,14 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('main_bp.contact') }}">Contato</a>
                     </li>
-                    {% if current_user.is_authenticated and current_user.role == 'student' %}
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('student_bp.dashboard') }}">Meu Painel</a></li>
+                    {% if current_user.is_authenticated %}
+                        {% if current_user.role == 'admin' %}
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_bp.dashboard') }}">Meu Painel</a></li>
+                        {% else %}
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('student_bp.dashboard') }}">Meu Painel</a></li>
+                        {% endif %}
                     {% else %}
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('student_bp.login') }}">Área do Aluno</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('student_bp.login') }}">Área do Aluno</a></li>
                     {% endif %}
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- Ensure `User.role` defaults to `student`
- Add student dashboard alias and flash-friendly admin guard
- Show proper dashboard link in navigation for admins and students

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e23344b48324bbda20490c429170