### PR TITLE
Configure Hotmart webhook secret

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,21 @@
+# Flask settings
+SECRET_KEY=change-me
+DATABASE_URL=sqlite:///dr_julio.db
+
+# Email settings
+MAIL_SERVER=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USE_TLS=true
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_DEFAULT_SENDER="Dr. Julio Vasconcelos <noreply@drjulio.com>"
+
+# Stripe settings
+STRIPE_SECRET_KEY=
+STRIPE_PUBLIC_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Hotmart settings
+HOTMART_WEBHOOK_SECRET=change-me
+HOTMART_CLIENT_ID=
+HOTMART_CLIENT_SECRET=


### PR DESCRIPTION
## Summary
- Add `.env` file including `HOTMART_WEBHOOK_SECRET` placeholder
- Confirm Hotmart webhook route validates signatures, enrolls users, and sends login instructions

## Testing
- `pytest tests/test_hotmart_webhook.py::test_hotmart_webhook_creates_enrollment -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4e61ecc8c8324ba1fc4bb8734b009