### PR TITLE
Link courses to Hotmart purchase

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -185,7 +185,7 @@ def cursos():
 
 @main_bp.route("/courses/<int:id>")
 def course_page(id):
-    """Show course details with a link to register."""
+    """Show course details with a link to purchase."""
     course = Course.query.get_or_404(id)
     settings = Settings.query.first()
     return render_template(

--- a/templates/course_catalog.html
+++ b/templates/course_catalog.html
@@ -17,7 +17,9 @@
                         <h5 class="card-title">{{ course.title }}</h5>
                         <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                         <p class="card-text">{{ course.description|truncate(150) }}</p>
-                        <a href="{{ url_for('main_bp.course_catalog_detail', course_id=course.id) }}" class="btn btn-consult">Ver Detalhes</a>
+                        {% if course.purchase_link %}
+                        <a href="{{ course.purchase_link }}" class="btn btn-consult" target="_blank">Comprar na Hotmart</a>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -47,7 +47,9 @@
                             <div>{{ course.description|safe }}</div>
                         </div>
                         <div class="modal-footer" style="border-top-color:#2d3748;">
-                            <a href="{{ url_for('main_bp.course_page', id=course.id) }}" class="btn btn-primary">Inscrever-se</a>
+                            {% if course.purchase_link %}
+                            <a href="{{ course.purchase_link }}" class="btn btn-primary" target="_blank">Comprar na Hotmart</a>
+                            {% endif %}
                             <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Fechar</button>
                         </div>
                     </div>

--- a/templates/public_course_detail.html
+++ b/templates/public_course_detail.html
@@ -16,7 +16,7 @@
                 <div class="card-body">
                     <p class="text-light mb-2">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                     {% if course.purchase_link %}
-                    <a href="{{ course.purchase_link }}" class="btn btn-primary w-100" target="_blank">Comprar Curso</a>
+                    <a href="{{ course.purchase_link }}" class="btn btn-primary w-100" target="_blank">Comprar na Hotmart</a>
                     {% endif %}
                 </div>
             </div>

--- a/templates/public_courses.html
+++ b/templates/public_courses.html
@@ -21,7 +21,9 @@
                         <p class="text-light">
                             <i class="fas fa-money-bill-wave me-2"></i> R$ {{ '%.2f'|format(course.price) }}
                         </p>
-                        <a href="{{ url_for('main_bp.course_page', id=course.id) }}" class="btn btn-primary">Detalhes</a>
+                        {% if course.purchase_link %}
+                        <a href="{{ course.purchase_link }}" class="btn btn-primary" target="_blank">Comprar na Hotmart</a>
+                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Route docstring now clarifies course pages link to purchase
- Replace detail/enroll buttons with Hotmart purchase links on course pages
- Update all course listings to point directly to Hotmart

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ecff5cd88324a74d70ce8d6c35fe