### PR TITLE
Remove course video upload support

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -35,17 +35,6 @@ def admin_required(f):
         return f(*args, **kwargs)
     return decorated_function
 
-
-def _save_course_video(course_id, file_storage):
-    if not file_storage:
-        return
-    filename = secure_filename(file_storage.filename)
-    content_folder = current_app.config['COURSE_CONTENT_FOLDER']
-    course_folder = os.path.join(content_folder, str(course_id))
-    os.makedirs(course_folder, exist_ok=True)
-    file_storage.save(os.path.join(course_folder, filename))
-
-
 @admin_bp.route('/login', methods=['GET', 'POST'])
 def login():
     if current_user.is_authenticated:
@@ -404,7 +393,6 @@ def add_course():
         )
         db.session.add(course)
         db.session.commit()
-        _save_course_video(course.id, form.video.data)
         flash('Curso adicionado!', 'success')
         return redirect(url_for('admin_bp.courses'))
     return render_template('admin/course_form.html', form=form, title='Novo Curso')
@@ -434,7 +422,6 @@ def edit_course(id):
             form.image.data.save(os.path.join(course_folder, filename))
             course.image = filename
         db.session.commit()
-        _save_course_video(course.id, form.video.data)
         flash('Curso atualizado!', 'success')
         return redirect(url_for('admin_bp.courses'))
     return render_template('admin/course_form.html', form=form, title='Editar Curso', course=course)

--- a/config.py
+++ b/config.py
@@ -14,7 +14,6 @@ class Config:
     
     # Upload folder for images
     UPLOAD_FOLDER = os.path.abspath(os.path.join(os.path.dirname(__file__), 'static/uploads'))
-    COURSE_CONTENT_FOLDER = os.path.abspath(os.path.join(os.path.dirname(__file__), 'course_content'))
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB max upload size
     
     # Email configuration

--- a/forms.py
+++ b/forms.py
@@ -110,7 +110,6 @@ class CourseForm(FlaskForm):
     title = StringField('Título', validators=[DataRequired()])
     description = TextAreaField('Descrição', validators=[DataRequired()])
     image = FileField('Imagem', validators=[FileAllowed(['jpg', 'jpeg', 'png'], 'Apenas imagens são permitidas!')])
-    video = FileField('Vídeo', validators=[FileAllowed(['mp4', 'mov', 'avi', 'mkv', 'webm'], 'Apenas vídeos são permitidos!'), Optional()])
     price = FloatField('Preço', validators=[DataRequired(), NumberRange(min=0)])
     access_url = StringField('URL de Acesso', validators=[Optional()])
     purchase_link = StringField('Link do curso', validators=[Optional(), URL()])

--- a/run.py
+++ b/run.py
@@ -10,9 +10,6 @@ if __name__ == '__main__':
     courses_dir = os.path.join(uploads_dir, 'courses')
     if not os.path.exists(courses_dir):
         os.makedirs(courses_dir)
-    content_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'course_content')
-    if not os.path.exists(content_dir):
-        os.makedirs(content_dir)
         
     # Run the application
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/templates/admin/course_form.html
+++ b/templates/admin/course_form.html
@@ -77,17 +77,6 @@
                     </div>
                 {% endif %}
             </div>
-            <div class="mb-3">
-                {{ form.video.label(class="form-label") }}
-                {{ form.video(class="form-control") }}
-                {% if form.video.errors %}
-                    <div class="text-danger">
-                        {% for error in form.video.errors %}
-                            <small>{{ error }}</small>
-                        {% endfor %}
-                    </div>
-                {% endif %}
-            </div>
             <div class="form-check form-switch mb-4">
                 {{ form.is_active(class="form-check-input") }}
                 {{ form.is_active.label(class="form-check-label") }}


### PR DESCRIPTION
## Summary
- drop video field from `CourseForm` and admin course template
- eliminate unused `_save_course_video` helper and config `COURSE_CONTENT_FOLDER`
- clean up run script and remove obsolete course content directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f101c41c83248d8e504b089763da