### PR TITLE
Ensure admin script resets role and password

### DIFF
--- a/create_admin.py
+++ b/create_admin.py
@@ -4,13 +4,12 @@ from models import db, User
 with app.app_context():
     admin = User.query.filter_by(username="admin").first()
     if not admin:
-        admin = User(username="admin", email="admin@drjulio.com", role='admin')
-        admin.set_password("12345678")
+        admin = User(username="admin", email="admin@drjulio.com")
         db.session.add(admin)
-        db.session.commit()
         print("✅ Usuário admin criado com sucesso.")
     else:
-        admin.role = 'admin'
-        admin.set_password("12345678")  # ou senha via env
-        db.session.commit()
         print("🔄 Usuário admin atualizado.")
+
+    admin.role = 'admin'
+    admin.set_password("12345678")  # ou senha via env
+    db.session.commit()


### PR DESCRIPTION
## Summary
- Refactor `create_admin.py` to always set the `admin` user's role and password, updating existing accounts as needed

## Testing
- `pip install -r requirements.txt`
- `flask db upgrade` *(fails: table appointment already exists)*
- `python create_admin.py`
- `python create_admin.py`
- `pytest` *(fails: UNIQUE constraint failed: user.username)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f49cab848324b35f9dce7295d75b