### PR TITLE
Redirect legacy course registration to purchase link

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -153,6 +153,15 @@ def course_page(id):
     )
 
 
+@main_bp.route("/courses/<int:id>/register")
+def course_register(id):
+    """Redirect legacy register route to external purchase link."""
+    course = Course.query.get_or_404(id)
+    if course.purchase_link:
+        return redirect(course.purchase_link)
+    return redirect(url_for("main_bp.course_page", id=id))
+
+
 @main_bp.route("/webhook/hotmart", methods=["POST"])
 def hotmart_webhook():
     """Handle Hotmart purchase notifications."""

--- a/templates/course_catalog.html
+++ b/templates/course_catalog.html
@@ -18,7 +18,7 @@
                         <p class="text-light">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                         <p class="card-text">{{ course.description|truncate(150) }}</p>
                         {% if course.purchase_link %}
-                        <a href="{{ course.purchase_link }}" class="btn btn-consult" target="_blank">Comprar na Hotmart</a>
+                        <a href="{{ course.purchase_link }}" class="btn btn-consult" target="_blank" rel="noopener">Comprar na Hotmart</a>
                         {% endif %}
                     </div>
                 </div>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -48,7 +48,7 @@
                         </div>
                         <div class="modal-footer" style="border-top-color:#2d3748;">
                             {% if course.purchase_link %}
-                            <a href="{{ course.purchase_link }}" class="btn btn-primary" target="_blank">Comprar na Hotmart</a>
+                            <a href="{{ course.purchase_link }}" class="btn btn-primary" target="_blank" rel="noopener">Comprar na Hotmart</a>
                             {% endif %}
                             <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Fechar</button>
                         </div>

--- a/templates/public_course_detail.html
+++ b/templates/public_course_detail.html
@@ -16,7 +16,7 @@
                 <div class="card-body">
                     <p class="text-light mb-2">Valor: R$ {{ '%.2f'|format(course.price) }}</p>
                     {% if course.purchase_link %}
-                    <a href="{{ course.purchase_link }}" class="btn btn-primary w-100" target="_blank">Comprar na Hotmart</a>
+                    <a href="{{ course.purchase_link }}" class="btn btn-primary w-100" target="_blank" rel="noopener">Comprar na Hotmart</a>
                     {% endif %}
                 </div>
             </div>

--- a/templates/public_courses.html
+++ b/templates/public_courses.html
@@ -22,7 +22,7 @@
                             <i class="fas fa-money-bill-wave me-2"></i> R$ {{ '%.2f'|format(course.price) }}
                         </p>
                         {% if course.purchase_link %}
-                        <a href="{{ course.purchase_link }}" class="btn btn-primary" target="_blank">Comprar na Hotmart</a>
+                        <a href="{{ course.purchase_link }}" class="btn btn-primary" target="_blank" rel="noopener">Comprar na Hotmart</a>
                         {% endif %}
                     </div>
                 </div>

--- a/tests/test_admin_course_crud.py
+++ b/tests/test_admin_course_crud.py
@@ -33,6 +33,7 @@ def test_admin_add_course(client):
         'description': 'desc',
         'price': '9.99',
         'access_url': 'http://example.com',
+        'purchase_link': 'http://buy.example.com',
         'is_active': 'y',
     }
     resp = client.post('/admin/courses/add', data=data, follow_redirects=True)
@@ -41,12 +42,13 @@ def test_admin_add_course(client):
         course = Course.query.filter_by(title='New Course').first()
         assert course is not None
         assert course.price == 9.99
+        assert course.purchase_link == 'http://buy.example.com'
 
 
 def test_admin_edit_course(client):
     with client.application.app_context():
         create_admin_user()
-        course = Course(title='Edit Me', description='d', price=1)
+        course = Course(title='Edit Me', description='d', price=1, purchase_link='http://old.example.com')
         db.session.add(course)
         db.session.commit()
         cid = course.id
@@ -56,6 +58,7 @@ def test_admin_edit_course(client):
         'description': 'new',
         'price': '2.5',
         'access_url': '',
+        'purchase_link': 'http://new.example.com',
         'is_active': 'y',
     }
     resp = client.post(f'/admin/courses/edit/{cid}', data=data, follow_redirects=True)
@@ -64,6 +67,7 @@ def test_admin_edit_course(client):
         course = Course.query.get(cid)
         assert course.title == 'Edited'
         assert course.price == 2.5
+        assert course.purchase_link == 'http://new.example.com'
 
 
 def test_admin_delete_course(client):

--- a/tests/test_courses.py
+++ b/tests/test_courses.py
@@ -34,12 +34,34 @@ def test_courses_route_english_alias(client):
 
 def test_course_page_shows_course_info(client):
     with client.application.app_context():
-        course = create_course(title='Course', description='desc', price=10, is_active=True)
+        course = create_course(
+            title='Course',
+            description='desc',
+            price=10,
+            is_active=True,
+            purchase_link='http://example.com/buy'
+        )
         url = f'/courses/{course.id}'
     resp = client.get(url)
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     assert 'Course' in html
+    assert 'http://example.com/buy' in html
+
+
+def test_course_register_redirects_to_purchase_link(client):
+    with client.application.app_context():
+        course = create_course(
+            title='Link Course',
+            description='desc',
+            price=10,
+            is_active=True,
+            purchase_link='http://example.com/register'
+        )
+        url = f'/courses/{course.id}/register'
+    resp = client.get(url, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == 'http://example.com/register'
 
 
 def test_active_courses_order_by_start_date(client):


### PR DESCRIPTION
## Summary
- Redirect `/courses/<id>/register` to the course's external `purchase_link`
- Update public course templates to point directly to the external purchase URL
- Expand tests to cover purchase link persistence and redirect behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f553311c832494f492c9af4314d4