### PR TITLE
Add student dashboard with role protection

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from extensions import db  # Correto: db importado do extensions.py
 from models import User, Settings
 from routes import main_bp
 from admin_routes import admin_bp
+from student_routes import student_bp
 
 # Create Flask application
 app = Flask(__name__)
@@ -25,6 +26,7 @@ mail = Mail(app)
 # Register blueprints
 app.register_blueprint(main_bp)
 app.register_blueprint(admin_bp, url_prefix='/admin')
+app.register_blueprint(student_bp)
 
 # Flask-Login: Carregador de usuário
 @login_manager.user_loader

--- a/student_routes.py
+++ b/student_routes.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from functools import wraps
+
+from flask import Blueprint, render_template, redirect, url_for, flash
+from flask_login import current_user
+
+from models import Settings
+
+
+student_bp = Blueprint("student_bp", __name__, url_prefix="/student")
+
+
+@student_bp.context_processor
+def inject_settings():
+    """Provide settings and current year to student templates."""
+    settings = Settings.query.first()
+    return {"settings": settings, "current_year": datetime.now().year}
+
+
+def student_required(f):
+    """Allow access only to authenticated users with the student role."""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if not current_user.is_authenticated or current_user.role != "student":
+            flash("Acesso restrito aos alunos", "danger")
+            return redirect(url_for("main_bp.index"))
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
+@student_bp.route("/dashboard")
+@student_required
+def dashboard():
+    """Simple student dashboard."""
+    return render_template("student/dashboard.html")
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ settings.site_title if settings and settings.site_title else 'Dr. Julio Vasconcelos' }} | {% block title %}{% endblock %}</title>
+    {# Determine the site title safely even when settings is missing #}
+    {% set site_title = settings.site_title if settings and settings.site_title else 'Dr. Julio Vasconcelos' %}
+    <title>{{ site_title }} | {% block title %}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
@@ -17,9 +19,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container">
-            <a class="navbar-brand" href="{{ url_for('main_bp.index') }}">
-                {% if settings and settings.site_title %}{{ settings.site_title }}{% else %}Dr. Julio Vasconcelos{% endif %}
-            </a>
+            <a class="navbar-brand" href="{{ url_for('main_bp.index') }}">{{ site_title }}</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -78,7 +78,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-4">
-                    <h5>{{ settings.site_title if settings and settings.site_title else 'Dr. Julio Vasconcelos' }}</h5>
+                    <h5>{{ site_title }}</h5>
                     {# Ensure settings exists before rendering about_text #}
                     {% if settings and settings.about_text %}
                         <p>{{ settings.about_text | truncate(100) }}</p>

--- a/templates/student/dashboard.html
+++ b/templates/student/dashboard.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Área do Aluno{% endblock %}
+{% block content %}
+<div class="container mt-4">
+    <h1>Bem-vindo à área do aluno</h1>
+</div>
+{% endblock %}

--- a/tests/test_student_dashboard.py
+++ b/tests/test_student_dashboard.py
@@ -1,0 +1,40 @@
+from models import db, User
+
+
+def create_user(username, role='student'):
+    user = User(username=username, email=f"{username}@example.com", role=role)
+    user.set_password('pass')
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login_user(client, user_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+        sess['_fresh'] = True
+
+
+def test_dashboard_requires_login(client):
+    resp = client.get('/student/dashboard')
+    assert resp.status_code == 302
+
+
+def test_dashboard_rejects_admin(client):
+    with client.application.app_context():
+        admin = create_user('admin', role='admin')
+        admin_id = admin.id
+    login_user(client, admin_id)
+    resp = client.get('/student/dashboard')
+    assert resp.status_code == 302
+
+
+def test_dashboard_allows_student(client):
+    with client.application.app_context():
+        student = create_user('stud', role='student')
+        student_id = student.id
+    login_user(client, student_id)
+    resp = client.get('/student/dashboard')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Área do Aluno' in html


### PR DESCRIPTION
## Summary
- add student blueprint with context processor and dashboard
- guard base template from missing settings
- ensure student dashboard restricted to users with student role

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f65dfdcc8324a719bd425a0eeffb