### PR TITLE
Use migrations for admin creation

### DIFF
--- a/create_admin.py
+++ b/create_admin.py
@@ -1,7 +1,11 @@
 from app import app
 from models import db, User
+from flask_migrate import upgrade
 
 with app.app_context():
+    # Ensure the database schema is up to date using migrations
+    upgrade()
+
     admin = User.query.filter_by(username="admin").first()
     if not admin:
         admin = User(username="admin", email="admin@drjulio.com")


### PR DESCRIPTION
## Summary
- Run database migrations in `create_admin.py` instead of using `db.create_all`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4f8877368832499999e09956db1e4